### PR TITLE
Improve NFC stability and launch web server

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,14 @@ else
   echo "⚠ Keine virtuelle Umgebung gefunden. Starte mit System-Python."
 fi
 
-# Anwendung starten (Vollbild-Modus)
+# Anwendung starten (Vollbild-Modus) und Webserver parallel
+echo "Starte Webserver..."
+python3 -m src.web.admin_server &
+WEB_PID=$!
+
+# Webserver bei Skriptende beenden
+trap "kill $WEB_PID" EXIT
+
 echo "Starte Anwendung..."
-python3 -m src.app 
+python3 -m src.app
+echo "Beende Webserver..."


### PR DESCRIPTION
## Summary
- handle missing NFC reader more gracefully
- show an error dialog when reading fails
- start the web admin server automatically from `start.sh`
- keep admin server running while GUI is open

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685aa64097d48327861cc869a6bb54e1