### PR TITLE
Add stop feature to admin web interface

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -5,6 +5,8 @@ from typing import Optional
 DB_PATH = Path(__file__).resolve().parent.parent / 'data' / 'getraenkekasse.db'
 
 REFRESH_FLAG = Path(__file__).resolve().parent.parent / 'data' / 'refresh.flag'
+# File that signals the application to terminate
+EXIT_FLAG = Path(__file__).resolve().parent.parent / 'data' / 'exit.flag'
 
 
 _SCHEMA = {
@@ -52,6 +54,25 @@ def touch_refresh_flag() -> None:
     """Create or update the refresh flag file."""
     REFRESH_FLAG.parent.mkdir(exist_ok=True)
     REFRESH_FLAG.touch()
+
+
+def set_exit_flag() -> None:
+    """Create the exit flag file to signal termination."""
+    EXIT_FLAG.parent.mkdir(exist_ok=True)
+    EXIT_FLAG.touch()
+
+
+def exit_flag_set() -> bool:
+    """Return True if an exit has been requested."""
+    return EXIT_FLAG.exists()
+
+
+def clear_exit_flag() -> None:
+    """Remove the exit flag file if it exists."""
+    try:
+        EXIT_FLAG.unlink()
+    except FileNotFoundError:
+        pass
 
 
 def refresh_needed(last_mtime: float) -> bool:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -173,6 +173,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
 
     def check_refresh(self) -> None:
+        if database.exit_flag_set():
+            database.clear_exit_flag()
+            QtWidgets.QApplication.quit()
+            return
         if database.refresh_needed(self.refresh_mtime):
             self.refresh_mtime = database.REFRESH_FLAG.stat().st_mtime
             self._rebuild_start_page()

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -47,6 +47,15 @@ def create_app() -> Flask:
         database.touch_refresh_flag()
         return redirect(url_for('index'))
 
+    @app.route('/stop', methods=['POST'])
+    @login_required
+    def stop():
+        database.set_exit_flag()
+        func = request.environ.get('werkzeug.server.shutdown')
+        if func:
+            func()
+        return 'Beende Anwendung...'
+
     @app.route('/password', methods=['GET', 'POST'])
     @login_required
     def change_password():

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -7,4 +7,8 @@
     <button type="submit">GUI aktualisieren</button>
 </form>
 
+<form method="post" action="{{ url_for('stop') }}" onsubmit="return confirm('Anwendung wirklich beenden?');">
+    <button type="submit">Beenden</button>
+</form>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- add EXIT_FLAG file helpers
- allow GUI to exit when exit flag is set
- add `/stop` route for admin interface
- add stop button on the admin home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bfd27ac088327b6b6f30104d3c7a8