### PR TITLE
Add NeoPixel status indicator

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -6,6 +6,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from .. import database
 from .. import models
 from .. import rfid
+from .. import led
 
 
 class QuantityDialog(QtWidgets.QDialog):
@@ -150,9 +151,11 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         user = models.get_user_by_uid(uid)
         if not user:
+            led.indicate_error()
             QtWidgets.QMessageBox.warning(self, "Fehler", "Unbekannte Karte")
             self.show_start_page()
             return
+        led.indicate_success()
         if not models.update_drink_stock(drink.id, -quantity):
             QtWidgets.QMessageBox.information(self, "Lager", "Nicht genug Bestand")
             self.show_start_page()

--- a/src/led.py
+++ b/src/led.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Control the NeoPixel strip for status feedback."""
+
+import threading
+import time
+from typing import Tuple, Optional
+
+try:
+    import board  # type: ignore
+    import neopixel  # type: ignore
+except Exception:  # pragma: no cover - optional hardware
+    board = None
+    neopixel = None
+
+_PIN = getattr(board, "D12", None) if board else None
+_LED_COUNT = 8
+_BRIGHTNESS = 0.2
+
+_pixels = None
+if neopixel and board and _PIN is not None:
+    _pixels = neopixel.NeoPixel(_PIN, _LED_COUNT, brightness=_BRIGHTNESS, auto_write=False)
+
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+
+
+def _fade_once(color: Tuple[int, int, int], delay: float = 0.01) -> None:
+    if not _pixels:
+        return
+    steps = list(range(0, 256, 8)) + list(range(255, -1, -8))
+    for val in steps:
+        scaled = tuple(int(val * c / 255) for c in color)
+        _pixels.fill(scaled)
+        _pixels.show()
+        time.sleep(delay)
+
+
+def _blink_loop(color: Tuple[int, int, int]) -> None:
+    while not _stop_event.is_set():
+        _fade_once(color)
+    if _pixels:
+        _pixels.fill((0, 0, 0))
+        _pixels.show()
+
+
+def _start_blink(color: Tuple[int, int, int]) -> None:
+    global _thread
+    stop()
+    if not _pixels:
+        return
+    _stop_event.clear()
+    _thread = threading.Thread(target=_blink_loop, args=(color,), daemon=True)
+    _thread.start()
+
+
+def stop() -> None:
+    global _thread
+    if _thread and _thread.is_alive():
+        _stop_event.set()
+        _thread.join()
+    _thread = None
+    if _pixels:
+        _pixels.fill((0, 0, 0))
+        _pixels.show()
+
+
+def flash(color: Tuple[int, int, int]) -> None:
+    stop()
+    _fade_once(color)
+    if _pixels:
+        _pixels.fill((0, 0, 0))
+        _pixels.show()
+
+
+# Convenience functions for the app
+
+def indicate_waiting() -> None:
+    """Blink blue while waiting for a card."""
+    _start_blink((0, 0, 255))
+
+
+def indicate_success() -> None:
+    """Show green to indicate success."""
+    flash((0, 255, 0))
+
+
+def indicate_error() -> None:
+    """Show red to indicate an error/unknown card."""
+    flash((255, 0, 0))

--- a/src/rfid.py
+++ b/src/rfid.py
@@ -6,6 +6,7 @@ import time
 from PyQt5 import QtWidgets, QtCore
 from mfrc522 import MFRC522
 import RPi.GPIO as GPIO
+from . import led
 
 # Unterdrücke "GPIO already in use"-Warnings
 GPIO.setwarnings(False)
@@ -14,6 +15,7 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
     """Liest nur die UID mit MFRC522, zeigt GUI an, keine AUTH ERRORs mehr."""
 
     reader = MFRC522()
+    led.indicate_waiting()
 
     app = QtWidgets.QApplication.instance()
     created_app = False
@@ -53,8 +55,10 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
 
         if uid_hex is None:
             print("Timeout: Keine Karte gelesen.")
+            led.stop()
     except Exception as e:
         print(f"Fehler beim Lesen: {e}")
+        led.stop()
     finally:
         if msg_box:
             msg_box.close()
@@ -62,6 +66,7 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
         if created_app:
             app.quit()
         GPIO.cleanup()
+        led.stop()
 
     return uid_hex
 


### PR DESCRIPTION
## Summary
- integrate NeoPixel strip for visual feedback
- add LED driver module
- show blue blinking when waiting for card, green for success and red for unknown card

## Testing
- `pytest -q`
- `python3 -m py_compile src/led.py src/rfid.py src/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_685bfe8b8b408327a02dfb18b0b5153b