### PR TITLE
Add log maintenance and CSV exports

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,9 @@ from .database import get_connection
 
 from . import rfid
 
+# Maximum number of transactions to keep in the log
+MAX_TRANSACTIONS = 10000
+
 
 
 @dataclass
@@ -65,6 +68,10 @@ def add_transaction(user_id: int, drink_id: int, quantity: int) -> None:
             conn.execute(
                 'INSERT INTO transactions (user_id, drink_id, quantity) VALUES (?, ?, ?)',
                 (user_id, drink_id, quantity))
+            conn.execute(
+                'DELETE FROM transactions WHERE id NOT IN ('
+                'SELECT id FROM transactions ORDER BY id DESC LIMIT ?)',
+                (MAX_TRANSACTIONS,))
             conn.commit()
     except sqlite3.Error as e:  # pragma: no cover - DB failure
         print(f"Fehler beim Schreiben der Transaktion: {e}")

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="de">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Admin</title>
     <style>
         body { margin:0; padding:0; font-family: Arial, sans-serif; background:#f0f0f0; }
@@ -17,6 +18,10 @@
         }
         .error { color:red; }
         .info { color:green; }
+        @media(max-width:600px){
+            nav a { display:block; margin:0.5em 0; }
+            table { font-size:0.9em; }
+        }
     </style>
 </head>
 <body>
@@ -26,6 +31,8 @@
     <a href="{{ url_for('users') }}">Benutzer</a>
     <a href="{{ url_for('log') }}">Log</a>
     <a href="{{ url_for('change_password') }}">Passwort</a>
+    <a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a>
+    <a href="{{ url_for('export_inventory') }}">CSV Bestand</a>
     <a href="{{ url_for('logout') }}">Logout</a>
 </nav>
 <div class="container">

--- a/src/web/templates/log.html
+++ b/src/web/templates/log.html
@@ -12,4 +12,7 @@
 </tr>
 {% endfor %}
 </table>
+<form method="post" action="{{ url_for('log_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
+    <button type="submit">Log löschen</button>
+</form>
 {% endblock %}

--- a/src/web/templates/user_edit.html
+++ b/src/web/templates/user_edit.html
@@ -5,7 +5,7 @@
     <label>Name:<br><input type="text" name="name" value="{{ user['name'] }}"></label><br>
     <label>UID:<br><input type="text" name="uid" id="uid_edit" value="{{ user['rfid_uid'] }}"></label>
     <button type="button" onclick="readUid('uid_edit')">UID lesen</button><br>
-    <label>Guthaben in Cent:<br><input type="number" name="balance" value="{{ user['balance'] }}"></label><br>
+    <label>Guthaben in Euro:<br><input type="number" step="0.01" name="balance" value="{{ (user['balance']/100)|round(2) }}"></label><br>
     <button type="submit">Speichern</button>
 </form>
 <script>

--- a/src/web/templates/users.html
+++ b/src/web/templates/users.html
@@ -32,14 +32,25 @@
 <form method="post" action="{{ url_for('users_topup') }}">
     <input type="text" name="uid" id="uid_topup" placeholder="UID">
     <button type="button" onclick="readUid('uid_topup')">UID lesen</button>
+    <span id="name_topup"></span>
     <input type="number" step="0.01" name="amount" placeholder="Betrag in Euro">
     <button type="submit">Aufladen</button>
 </form>
 
 <script>
+function updateName() {
+    var uid = document.getElementById('uid_topup').value;
+    if(!uid) { document.getElementById('name_topup').innerText = ''; return; }
+    fetch('{{ url_for('user_name') }}?uid=' + encodeURIComponent(uid)).then(r => r.json()).then(data => {
+        document.getElementById('name_topup').innerText = data.name || 'Unbekannt';
+    });
+}
+document.getElementById('uid_topup').addEventListener('change', updateName);
 function readUid(targetId) {
     fetch('{{ url_for('read_uid') }}').then(r => r.json()).then(data => {
-        document.getElementById(targetId).value = data.uid;
+        var el = document.getElementById(targetId);
+        el.value = data.uid;
+        if(targetId === 'uid_topup') updateName();
     });
 }
 </script>


### PR DESCRIPTION
## Summary
- keep log size manageable by pruning after each transaction
- allow clearing the log in the admin interface
- add CSV exports for transactions and inventory
- show user name when topping up credit
- accept/enter user balances in Euro
- tweak web UI for mobile and desktop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c571f7d58832795d5a6efc6e51113