### PR TITLE
Add overdraft limit and allow negative stock

### DIFF
--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -89,6 +89,20 @@ def create_app() -> Flask:
                 info = 'Passwort gespeichert'
         return render_template('change_password.html', error=error, info=info)
 
+    @app.route('/settings', methods=['GET', 'POST'])
+    @login_required
+    def settings():
+        conn = database.get_connection()
+        current_limit = models.get_overdraft_limit(conn)
+        if request.method == 'POST':
+            val = request.form.get('overdraft', type=float)
+            if val is not None:
+                models.set_overdraft_limit(int(val * 100), conn)
+            conn.close()
+            return redirect(url_for('settings'))
+        conn.close()
+        return render_template('settings.html', overdraft_limit=current_limit)
+
 
     @app.route('/login', methods=['GET', 'POST'])
     def login():

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -8,7 +8,7 @@
         body { margin:0; padding:0; font-family: Arial, sans-serif; background:#f0f0f0; }
         nav { background:#003366; padding:1em; }
         nav a { color:#fff; text-decoration:none; margin-right:1em; font-size:1.1em; }
-        nav a:hover { text-decoration:underline; }
+nav a:hover { text-decoration:underline; }
         .container { max-width:1000px; margin:1em auto; background:#fff; padding:1em; box-shadow:0 0 10px rgba(0,0,0,0.1); }
         table { width:100%; border-collapse:collapse; margin-bottom:1em; }
         th, td { border:1px solid #ccc; padding:0.5em; text-align:left; }
@@ -18,6 +18,7 @@
         }
         .error { color:red; }
         .info { color:green; }
+        .negstock { background:#fdd; }
         @media(max-width:600px){
             nav a { display:block; margin:0.5em 0; }
             table { font-size:0.9em; }
@@ -30,6 +31,7 @@
     <a href="{{ url_for('drinks') }}">Getränke</a>
     <a href="{{ url_for('users') }}">Benutzer</a>
     <a href="{{ url_for('log') }}">Log</a>
+    <a href="{{ url_for('settings') }}">Einstellungen</a>
     <a href="{{ url_for('change_password') }}">Passwort</a>
     <a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a>
     <a href="{{ url_for('export_inventory') }}">CSV Bestand</a>

--- a/src/web/templates/drinks.html
+++ b/src/web/templates/drinks.html
@@ -5,7 +5,7 @@
 
 <tr><th>Name</th><th>Preis</th><th>Lager</th><th>Auffüllen</th><th colspan="2">Aktion</th></tr>
 {% for d in drinks %}
-<tr>
+<tr class="{% if d['stock'] < 0 %}negstock{% endif %}">
 <td>{{ d['name'] }}</td>
 <td>{{ (d['price']/100)|round(2) }} €</td>
 <td>{{ d['stock'] }}</td>

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Einstellungen</h1>
+<form method="post">
+    <label>Überziehungslimit in Euro:<br>
+        <input type="number" step="0.01" name="overdraft" value="{{ overdraft_limit/100 }}">
+    </label><br>
+    <button type="submit">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow negative stock and highlight in red
- support overdraft limit via new config table
- add settings page in admin UI
- mark drinks with negative stock in GUI
- show hint when balance below 0
- limit visible drinks to nine

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c5f513e7c832793a44d331d549924