### PR TITLE
Add serial LED module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nfcpy>=1.0
 mfrc522
 rpi_ws281x
 adafruit-circuitpython-neopixel
+pyserial>=3.0

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -6,6 +6,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from .. import database
 from .. import models
 from .. import rfid
+from .. import led
 
 
 class QuantityDialog(QtWidgets.QDialog):
@@ -155,6 +156,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         user = models.get_user_by_uid(uid)
         if not user:
+            led.indicate_error()
             QtWidgets.QMessageBox.warning(self, "Fehler", "Unbekannte Karte")
             self.show_start_page()
             return
@@ -167,6 +169,7 @@ class MainWindow(QtWidgets.QMainWindow):
         models.update_drink_stock(drink.id, -quantity)
         models.add_transaction(user.id, drink.id, quantity)
         new_user = models.get_user_by_uid(uid)
+        led.indicate_success()
         msg = (
             f"Danke {new_user.name}!\nAltes Guthaben: {old_balance/100:.2f} €\n"
             f"Neues Guthaben: {new_user.balance/100:.2f} €"

--- a/src/led.py
+++ b/src/led.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Serial based control for an external Arduino NeoPixel controller."""
+
+from typing import Optional
+import os
+
+try:
+    import serial  # type: ignore
+except Exception as e:  # pragma: no cover - optional dependency
+    serial = None  # type: ignore
+    print(f"pyserial not available: {e}")
+
+
+_PORT_CANDIDATES = ["/dev/ttyUSB0", "/dev/ttyACM0"]
+_BAUDRATE = 115200
+
+_serial: Optional["serial.Serial"] = None
+
+
+def _init_serial() -> None:
+    global _serial
+    if serial is None:
+        return
+    for port in _PORT_CANDIDATES:
+        if not os.path.exists(port):
+            continue
+        try:
+            _serial = serial.Serial(port, _BAUDRATE, timeout=1)
+            break
+        except Exception as exc:  # pragma: no cover - hardware might be missing
+            print(f"LED serial port {port} could not be opened: {exc}")
+            _serial = None
+    if _serial is None:
+        print("LED controller not found - LEDs disabled")
+
+
+_init_serial()
+
+
+def _send(cmd: str) -> None:
+    if _serial and _serial.is_open:
+        try:
+            _serial.write(cmd.encode("utf-8"))
+        except Exception as exc:  # pragma: no cover - serial failure
+            print(f"Error sending to LED controller: {exc}")
+
+
+def indicate_waiting() -> None:
+    """Show waiting animation (blue chase)."""
+    _send("card_read\n")
+
+
+def indicate_success() -> None:
+    """Turn strip green."""
+    _send("success\n")
+
+
+def indicate_error() -> None:
+    """Turn strip red."""
+    _send("error\n")
+
+
+def off() -> None:
+    """Switch off all LEDs."""
+    _send("off\n")
+
+
+def stop() -> None:
+    """Alias for :func:`off`."""
+    off()

--- a/src/rfid.py
+++ b/src/rfid.py
@@ -5,6 +5,8 @@ from typing import Optional
 import time
 from PyQt5 import QtWidgets, QtCore
 
+from . import led
+
 try:
     from mfrc522 import MFRC522
     import RPi.GPIO as GPIO
@@ -24,6 +26,7 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
         return None
 
     reader = MFRC522()
+    led.indicate_waiting()
 
     app = QtWidgets.QApplication.instance()
     created_app = False
@@ -76,6 +79,7 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
             app.quit()
         if GPIO:
             GPIO.cleanup()
+        led.off()
 
     return uid_hex
 


### PR DESCRIPTION
## Summary
- add `led.py` for serial control of an external Arduino
- integrate LED feedback into RFID handling and GUI
- require `pyserial` in requirements

## Testing
- `python3 -m py_compile src/led.py src/rfid.py src/gui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_685d664cbd8c8327aa43b7908ad68433