### PR TITLE
Add inventory and user management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,19 @@ Das Admin-Passwort lässt sich im Web-Admin über den Punkt "Passwort" ändern.
 
 
 Diese Implementierung dient als Ausgangspunkt und kann nach Bedarf erweitert werden (z.B. weitere Admin-Funktionen, Export, Hardware-Anbindung des RFID-Lesers).
+
+## Update von älteren Versionen
+
+Um die neuen Funktionen (z.B. Auflade- und Bestandslog) ohne Datenverlust zu nutzen,
+reicht es aus, das Repository zu aktualisieren und die Datenbanktabellen anzulegen.
+Führe dazu einfach folgende Schritte aus:
+
+```bash
+# Im Projektordner
+./update.sh
+```
+
+Das Skript holt die neuesten Dateien, installiert benötigte Pakete und ruft
+`init_db()` auf. Bestehende Daten wie Benutzer, Guthaben, Bilder und Getränke
+bleiben erhalten. Beim Start des Webservers werden neue Tabellen automatisch
+verwendet.

--- a/src/database.py
+++ b/src/database.py
@@ -40,6 +40,24 @@ _SCHEMA = {
         'FOREIGN KEY(drink_id) REFERENCES drinks(id)'
         ')'
     ),
+    'restocks': (
+        'CREATE TABLE IF NOT EXISTS restocks ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+        'drink_id INTEGER NOT NULL, '
+        'quantity INTEGER NOT NULL, '
+        'timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'FOREIGN KEY(drink_id) REFERENCES drinks(id)'
+        ')'
+    ),
+    'topups': (
+        'CREATE TABLE IF NOT EXISTS topups ('
+        'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+        'user_id INTEGER NOT NULL, '
+        'amount INTEGER NOT NULL, '
+        'timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,'
+        'FOREIGN KEY(user_id) REFERENCES users(id)'
+        ')'
+    ),
     'config': (
         'CREATE TABLE IF NOT EXISTS config ('
         'key TEXT PRIMARY KEY, '

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -218,8 +218,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if new_user.balance < 0:
             msg += "\nBitte Guthaben aufladen!"
         self.info_label.setText(msg)
-        QtCore.QTimer.singleShot(3000, self.show_start_page)
         self.stack.setCurrentWidget(self.info_label)
+        QtWidgets.QApplication.processEvents()
+        QtCore.QTimer.singleShot(4000, self.show_start_page)
 
 
     def check_refresh(self) -> None:
@@ -227,7 +228,7 @@ class MainWindow(QtWidgets.QMainWindow):
             database.clear_exit_flag()
             QtWidgets.QApplication.quit()
             return
-        if database.refresh_needed(self.refresh_mtime):
+        if self.stack.currentWidget() is self.start_page and database.refresh_needed(self.refresh_mtime):
             self.refresh_mtime = database.REFRESH_FLAG.stat().st_mtime
             self._rebuild_start_page()
 

--- a/src/models.py
+++ b/src/models.py
@@ -120,6 +120,67 @@ def update_drink_stock(drink_id: int, diff: int) -> bool:
         return False
 
 
+def log_restock(drink_id: int, quantity: int) -> None:
+    """Record a restock event."""
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                'INSERT INTO restocks (drink_id, quantity) VALUES (?, ?)',
+                (drink_id, quantity),
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - DB failure
+        print(f"Fehler beim Schreiben der Auffüllung: {e}")
+
+
+def get_restock_log(limit: int | None = None) -> list[sqlite3.Row]:
+    try:
+        with get_connection() as conn:
+            query = (
+                'SELECT r.timestamp, d.name as drink_name, r.quantity '
+                'FROM restocks r JOIN drinks d ON d.id = r.drink_id '
+                'ORDER BY r.timestamp DESC'
+            )
+            if limit is not None:
+                query += f' LIMIT {int(limit)}'
+            cur = conn.execute(query)
+            return cur.fetchall()
+    except sqlite3.Error as e:  # pragma: no cover
+        print(f"Fehler beim Lesen der Auffüllungen: {e}")
+        return []
+
+
+def add_topup(user_id: int, amount: int) -> None:
+    """Store a top-up event and keep only the most recent 50."""
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                'INSERT INTO topups (user_id, amount) VALUES (?, ?)',
+                (user_id, amount),
+            )
+            conn.execute(
+                'DELETE FROM topups WHERE id NOT IN ('
+                'SELECT id FROM topups ORDER BY id DESC LIMIT 50)'
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - DB failure
+        print(f"Fehler beim Schreiben der Aufladung: {e}")
+
+
+def get_topup_log() -> list[sqlite3.Row]:
+    try:
+        with get_connection() as conn:
+            cur = conn.execute(
+                'SELECT t.timestamp, u.name as user_name, t.amount '
+                'FROM topups t JOIN users u ON u.id = t.user_id '
+                'ORDER BY t.timestamp DESC'
+            )
+            return cur.fetchall()
+    except sqlite3.Error as e:  # pragma: no cover
+        print(f"Fehler beim Lesen der Aufladungen: {e}")
+        return []
+
+
 def get_drink_by_id(drink_id: int) -> Optional[Drink]:
     try:
         with get_connection() as conn:

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -184,6 +184,7 @@ def create_app() -> Flask:
                 conn.execute('UPDATE drinks SET stock=? WHERE id=?', (new_stock, drink_id))
                 conn.commit()
                 conn.close()
+                models.log_restock(drink_id, amount)
                 database.touch_refresh_flag()
             else:
                 conn.close()
@@ -226,6 +227,45 @@ def create_app() -> Flask:
         conn.close()
         return render_template('users.html', users=items, error=error)
 
+    @app.route('/topup')
+    @login_required
+    def topup():
+        conn = database.get_connection()
+        cur = conn.execute('SELECT id, name FROM users ORDER BY name')
+        items = cur.fetchall()
+        conn.close()
+        return render_template('topup.html', users=items)
+
+    @app.route('/topup/submit', methods=['POST'])
+    @login_required
+    def topup_submit():
+        uid = request.form.get('uid')
+        name = request.form.get('user_name')
+        amount_euro = request.form.get('amount', type=float)
+        if amount_euro is None:
+            return redirect(url_for('topup'))
+        user = None
+        if uid:
+            user = models.get_user_by_uid(uid)
+        elif name:
+            conn = database.get_connection()
+            cur = conn.execute('SELECT * FROM users WHERE name=?', (name,))
+            row = cur.fetchone()
+            conn.close()
+            if row:
+                user = models.User(**row)
+        if user:
+            cents = int(amount_euro * 100)
+            models.update_balance(user.id, cents)
+            models.add_topup(user.id, cents)
+        return redirect(url_for('topup'))
+
+    @app.route('/topup_log')
+    @login_required
+    def topup_log():
+        items = models.get_topup_log()
+        return render_template('topup_log.html', items=items)
+
     @app.route('/users/add', methods=['POST'])
     @login_required
     def user_add():
@@ -261,7 +301,9 @@ def create_app() -> Flask:
         if uid and amount_euro is not None:
             user = models.get_user_by_uid(uid)
             if user:
-                models.update_balance(user.id, int(amount_euro * 100))
+                cents = int(amount_euro * 100)
+                models.update_balance(user.id, cents)
+                models.add_topup(user.id, cents)
                 return redirect(url_for('users'))
             else:
                 return users(error='Unbekannte UID')
@@ -307,14 +349,16 @@ def create_app() -> Flask:
             'JOIN drinks d ON d.id = t.drink_id '
             'ORDER BY t.timestamp DESC LIMIT 100')
         items = cur.fetchall()
+        restocks = models.get_restock_log(100)
         conn.close()
-        return render_template('log.html', items=items)
+        return render_template('log.html', items=items, restocks=restocks)
 
     @app.route('/log/clear', methods=['POST'])
     @login_required
     def log_clear():
         conn = database.get_connection()
         conn.execute('DELETE FROM transactions')
+        conn.execute('DELETE FROM restocks')
         conn.commit()
         conn.close()
         return redirect(url_for('log'))
@@ -356,6 +400,77 @@ def create_app() -> Flask:
         resp = make_response(out.getvalue())
         resp.headers['Content-Type'] = 'text/csv'
         resp.headers['Content-Disposition'] = 'attachment; filename=inventory.csv'
+        return resp
+
+    @app.route('/export/users')
+    @login_required
+    def export_users():
+        conn = database.get_connection()
+        cur = conn.execute('SELECT name, rfid_uid, balance FROM users ORDER BY name')
+        rows = cur.fetchall()
+        conn.close()
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['name', 'uid', 'balance_euro'])
+        for r in rows:
+            writer.writerow([r['name'], r['rfid_uid'], f"{r['balance']/100:.2f}"])
+        resp = make_response(out.getvalue())
+        resp.headers['Content-Type'] = 'text/csv'
+        resp.headers['Content-Disposition'] = 'attachment; filename=users.csv'
+        return resp
+
+    @app.route('/import/users', methods=['GET', 'POST'])
+    @login_required
+    def import_users():
+        if request.method == 'POST':
+            file = request.files.get('file')
+            if file and file.filename:
+                content = io.StringIO(file.stream.read().decode('utf-8'))
+                reader = csv.DictReader(content)
+                conn = database.get_connection()
+                for row in reader:
+                    try:
+                        conn.execute(
+                            'INSERT INTO users (name, rfid_uid, balance) VALUES (?, ?, ?)',
+                            (
+                                row.get('name'),
+                                row.get('uid'),
+                                int(float(row.get('balance_euro', 0)) * 100),
+                            ),
+                        )
+                    except sqlite3.IntegrityError:
+                        pass
+                conn.commit()
+                conn.close()
+            return redirect(url_for('users'))
+        return render_template('import_users.html')
+
+    @app.route('/export/restocks')
+    @login_required
+    def export_restocks():
+        rows = models.get_restock_log()
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['timestamp', 'drink', 'quantity'])
+        for r in rows:
+            writer.writerow([r['timestamp'], r['drink_name'], r['quantity']])
+        resp = make_response(out.getvalue())
+        resp.headers['Content-Type'] = 'text/csv'
+        resp.headers['Content-Disposition'] = 'attachment; filename=restocks.csv'
+        return resp
+
+    @app.route('/export/topups')
+    @login_required
+    def export_topups():
+        rows = models.get_topup_log()
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['timestamp', 'user', 'amount_euro'])
+        for r in rows:
+            writer.writerow([r['timestamp'], r['user_name'], f"{r['amount']/100:.2f}"])
+        resp = make_response(out.getvalue())
+        resp.headers['Content-Type'] = 'text/csv'
+        resp.headers['Content-Disposition'] = 'attachment; filename=topups.csv'
         return resp
 
     return app

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -30,11 +30,17 @@ nav a:hover { text-decoration:underline; }
     <a href="{{ url_for('index') }}">Home</a>
     <a href="{{ url_for('drinks') }}">Getränke</a>
     <a href="{{ url_for('users') }}">Benutzer</a>
+    <a href="{{ url_for('topup') }}">Aufladen</a>
     <a href="{{ url_for('log') }}">Log</a>
+    <a href="{{ url_for('topup_log') }}">Aufladungen</a>
     <a href="{{ url_for('settings') }}">Einstellungen</a>
     <a href="{{ url_for('change_password') }}">Passwort</a>
     <a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a>
     <a href="{{ url_for('export_inventory') }}">CSV Bestand</a>
+    <a href="{{ url_for('export_restocks') }}">CSV Auffüllungen</a>
+    <a href="{{ url_for('export_topups') }}">CSV Aufladungen</a>
+    <a href="{{ url_for('export_users') }}">CSV Benutzer</a>
+    <a href="{{ url_for('import_users') }}">Import Benutzer</a>
     <a href="{{ url_for('logout') }}">Logout</a>
 </nav>
 <div class="container">

--- a/src/web/templates/import_users.html
+++ b/src/web/templates/import_users.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Benutzer importieren</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="file">
+    <button type="submit">Importieren</button>
+</form>
+<p>CSV Spalten: name, uid, balance_euro</p>
+{% endblock %}

--- a/src/web/templates/log.html
+++ b/src/web/templates/log.html
@@ -15,4 +15,16 @@
 <form method="post" action="{{ url_for('log_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>
+
+<h2>Auffüllungen</h2>
+<table>
+<tr><th>Zeitpunkt</th><th>Getränk</th><th>Menge</th></tr>
+{% for r in restocks %}
+<tr>
+<td>{{ r['timestamp'] }}</td>
+<td>{{ r['drink_name'] }}</td>
+<td>{{ r['quantity'] }}</td>
+</tr>
+{% endfor %}
+</table>
 {% endblock %}

--- a/src/web/templates/topup.html
+++ b/src/web/templates/topup.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Guthaben aufladen</h1>
+<form method="post" action="{{ url_for('topup_submit') }}">
+    <label>UID scannen:<br>
+        <input type="text" name="uid" id="uid_scan">
+        <button type="button" onclick="readUid('uid_scan')">UID lesen</button>
+    </label>
+    <p><strong>oder</strong></p>
+    <label>Benutzername:<br>
+        <input list="userlist" name="user_name" id="user_name">
+        <datalist id="userlist">
+            {% for u in users %}
+            <option value="{{ u['name'] }}">
+            {% endfor %}
+        </datalist>
+    </label>
+    <label>Betrag in Euro:<br>
+        <input type="number" step="0.01" name="amount">
+    </label>
+    <button type="submit">Aufladen</button>
+</form>
+<script>
+function readUid(target){
+    fetch('{{ url_for('read_uid') }}').then(r=>r.json()).then(d=>{
+        document.getElementById(target).value=d.uid;
+    });
+}
+</script>
+{% endblock %}

--- a/src/web/templates/topup_log.html
+++ b/src/web/templates/topup_log.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Aufladungen</h1>
+<table>
+<tr><th>Zeitpunkt</th><th>Benutzer</th><th>Betrag</th></tr>
+{% for r in items %}
+<tr>
+<td>{{ r['timestamp'] }}</td>
+<td>{{ r['user_name'] }}</td>
+<td>{{ (r['amount']/100)|round(2) }} €</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/src/web/templates/users.html
+++ b/src/web/templates/users.html
@@ -14,7 +14,7 @@
 <td>{{ (u['balance']/100)|round(2) }} €</td>
 
 <td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
-<td><a href="{{ url_for('user_delete', user_id=u['id']) }}">Löschen</a></td>
+<td><a href="{{ url_for('user_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
 </tr>
 {% endfor %}
 </table>
@@ -29,6 +29,7 @@
 </form>
 
 <h2>Guthaben aufladen</h2>
+<p>Für eine komfortable Ansicht siehe <a href="{{ url_for('topup') }}">Aufladen</a>.</p>
 <form method="post" action="{{ url_for('users_topup') }}">
     <input type="text" name="uid" id="uid_topup" placeholder="UID">
     <button type="button" onclick="readUid('uid_topup')">UID lesen</button>

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Pull latest changes if repository has remote
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  git pull
+fi
+
+# Create venv if missing and install requirements
+if [ ! -d venv ]; then
+  python3 -m venv venv --system-site-packages
+fi
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Create any new database tables without touching existing data
+venv/bin/python - <<'PY'
+import src.database as d
+conn = d.get_connection()
+d.init_db(conn)
+conn.close()
+PY
+
+echo "Update completed"


### PR DESCRIPTION
## Summary
- add restock and topup tables to the DB schema
- support logging of restocks and topups in the models
- add new topup page and topup log
- extend admin web server with import/export features and restock logging
- improve navigation and confirm deleting users
- add update script and instructions for safe upgrades
- show success screen longer after purchases

## Testing
- `pytest -q`
- `python -m py_compile src/web/admin_server.py src/models.py src/database.py src/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6880a9813bc88327a309ea108e2481b5