### PR TITLE
Add admin pin and stock dashboard

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -25,7 +25,8 @@ _SCHEMA = {
         'price INTEGER NOT NULL, '
 
         'image TEXT, '
-        'stock INTEGER NOT NULL DEFAULT 0'
+        'stock INTEGER NOT NULL DEFAULT 0, '
+        'min_stock INTEGER NOT NULL DEFAULT 0'
 
         ')'
     ),
@@ -125,6 +126,9 @@ def init_db(conn: Optional[sqlite3.Connection] = None) -> None:
     cursor.execute(
         "INSERT OR IGNORE INTO config (key, value) VALUES ('topup_uid', '')"
     )
+    cursor.execute(
+        "INSERT OR IGNORE INTO config (key, value) VALUES ('admin_pin', '1234')"
+    )
     conn.commit()
     add_sample_data(conn)
     if own_conn:
@@ -147,11 +151,11 @@ def add_sample_data(conn: sqlite3.Connection) -> None:
     if cur.fetchone()[0] == 0:
         conn.execute(
 
-            'INSERT INTO drinks (name, price, stock) VALUES (?, ?, ?)',
-            ('Wasser', 150, 20))
+            'INSERT INTO drinks (name, price, stock, min_stock) VALUES (?, ?, ?, ?)',
+            ('Wasser', 150, 20, 5))
         conn.execute(
-            'INSERT INTO drinks (name, price, stock) VALUES (?, ?, ?)',
-            ('Cola', 200, 15))
+            'INSERT INTO drinks (name, price, stock, min_stock) VALUES (?, ?, ?, ?)',
+            ('Cola', 200, 15, 5))
 
 
     conn.commit()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -190,6 +190,13 @@ class MainWindow(QtWidgets.QMainWindow):
         bottom = layout.rowCount()
         layout.addWidget(self.buy_button, bottom, 0)
         layout.addWidget(self.cancel_button, bottom, 1)
+        self.admin_button = QtWidgets.QPushButton("Admin")
+        f = self.admin_button.font()
+        f.setPointSize(12)
+        self.admin_button.setFont(f)
+        self.admin_button.setFixedSize(80, 40)
+        self.admin_button.clicked.connect(self._open_admin)
+        layout.addWidget(self.admin_button, bottom, 2, alignment=QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight)
         layout.setRowStretch(bottom, 0)
         self.buy_button.hide()
         self.cancel_button.hide()
@@ -207,7 +214,10 @@ class MainWindow(QtWidgets.QMainWindow):
             cash_id = models.get_cash_user_id()
             models.add_transaction(cash_id, drink.id, quantity)
             led.indicate_success()
-            self.info_label.setText("Barverkauf verbucht")
+            total_price = drink.price * quantity
+            self.info_label.setText(
+                f"Bitte {total_price/100:.2f} \u20ac passend in die Getränkekasse legen"
+            )
             self.stack.setCurrentWidget(self.info_label)
             QtCore.QTimer.singleShot(2000, self.show_start_page)
             return
@@ -301,4 +311,18 @@ class MainWindow(QtWidgets.QMainWindow):
         self.info_label.setText(msg)
         QtCore.QTimer.singleShot(3000, self.show_start_page)
         self.stack.setCurrentWidget(self.info_label)
+
+    def _open_admin(self) -> None:
+        pin, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "PIN",
+            "Admin-PIN:",
+            QtWidgets.QLineEdit.Password,
+        )
+        if not ok:
+            return
+        if pin == models.get_admin_pin():
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://localhost:8000"))
+        else:
+            QtWidgets.QMessageBox.warning(self, "Fehler", "Falscher PIN")
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -57,6 +57,7 @@
             <ul class="submenu">
                 <li><a href="{{ url_for('log') }}">Verkäufe</a></li>
                 <li><a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a></li>
+                <li><a href="{{ url_for('file_logs') }}">Programmlogs</a></li>
             </ul>
         </li>
         <li><a href="{{ url_for('settings') }}">Einstellungen</a></li>

--- a/src/web/templates/drink_edit.html
+++ b/src/web/templates/drink_edit.html
@@ -5,6 +5,7 @@
     <label>Name:<br><input type="text" name="name" value="{{ drink['name'] }}"></label><br>
     <label>Preis in Euro:<br><input type="number" step="0.01" name="price" value="{{ (drink['price']/100)|round(2) }}"></label><br>
     <label>Lagerbestand:<br><input type="number" name="stock" value="{{ drink['stock'] }}"></label><br>
+    <label>Mindestbestand:<br><input type="number" name="min_stock" value="{{ drink['min_stock'] }}"></label><br>
     <input type="hidden" name="current_image" value="{{ drink['image'] }}">
     <label>Logo (optional):<br><input type="file" name="image"></label><br>
     <button type="submit">Speichern</button>

--- a/src/web/templates/drinks.html
+++ b/src/web/templates/drinks.html
@@ -3,12 +3,13 @@
 <h1>Getränke</h1>
 <table>
 
-<tr><th>Name</th><th>Preis</th><th>Lager</th><th>Auffüllen</th><th colspan="2">Aktion</th></tr>
+<tr><th>Name</th><th>Preis</th><th>Lager</th><th>Mindestens</th><th>Auffüllen</th><th colspan="2">Aktion</th></tr>
 {% for d in drinks %}
-<tr class="{% if d['stock'] < 0 %}negstock{% endif %}">
+<tr class="{% if d['stock'] < d['min_stock'] %}negstock{% endif %}">
 <td>{{ d['name'] }}</td>
 <td>{{ (d['price']/100)|round(2) }} €</td>
 <td>{{ d['stock'] }}</td>
+<td>{{ d['min_stock'] }}</td>
 
 <td>
   <form method="post" action="{{ url_for('drink_restock', drink_id=d['id']) }}" style="display:inline">
@@ -27,6 +28,7 @@
 
     <input type="number" step="0.01" name="price" placeholder="Preis in Euro">
     <input type="number" name="stock" placeholder="Lagerbestand">
+    <input type="number" name="min_stock" placeholder="Mindestbestand">
     <input type="file" name="image">
 
     <button type="submit">Hinzufügen</button>

--- a/src/web/templates/file_logs.html
+++ b/src/web/templates/file_logs.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Programmlogs</h1>
+{% if files %}
+<table>
+<tr><th>Datei</th><th>Aktion</th></tr>
+{% for f in files %}
+<tr><td>{{ f }}</td>
+<td>
+<form method="post" action="{{ url_for('file_logs_delete', name=f) }}" onsubmit="return confirm('Log wirklich löschen?');">
+<button type="submit">Löschen</button>
+</form>
+</td></tr>
+{% endfor %}
+</table>
+{% else %}
+<p>Keine Logs vorhanden.</p>
+{% endif %}
+{% endblock %}

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -11,4 +11,18 @@
     <button type="submit">Beenden</button>
 </form>
 
+{% if to_buy %}
+<h2>Nachkaufen</h2>
+<table>
+<tr><th>Getränk</th><th>Bestand</th><th>Mindest</th></tr>
+{% for d in to_buy %}
+<tr class="{% if d.stock < d.min_stock %}negstock{% endif %}">
+<td>{{ d.name }}</td>
+<td>{{ d.stock }}</td>
+<td>{{ d.min_stock }}</td>
+</tr>
+{% endfor %}
+</table>
+{% endif %}
+
 {% endblock %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -9,6 +9,9 @@
         <input type="text" name="topup_uid" id="topup_uid" value="{{ topup_uid }}">
     </label>
     <button type="button" onclick="readUid('topup_uid')">UID lesen</button><br>
+    <label>Admin-PIN:<br>
+        <input type="text" name="admin_pin" value="{{ admin_pin }}">
+    </label><br>
     <button type="submit">Speichern</button>
 </form>
 <script>

--- a/update.sh
+++ b/update.sh
@@ -18,6 +18,14 @@ venv/bin/python - <<'PY'
 import src.database as d
 conn = d.get_connection()
 d.init_db(conn)
+cur = conn.execute("PRAGMA table_info(drinks)")
+cols = [r[1] for r in cur.fetchall()]
+if 'min_stock' not in cols:
+    conn.execute("ALTER TABLE drinks ADD COLUMN min_stock INTEGER NOT NULL DEFAULT 0")
+cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='admin_pin'")
+if cur.fetchone()[0] == 0:
+    conn.execute("INSERT INTO config(key, value) VALUES ('admin_pin', '1234')")
+conn.commit()
 conn.close()
 PY
 


### PR DESCRIPTION
## Summary
- add admin PIN setting and button in GUI to open the web interface
- store minimal stock and show items to restock on admin dashboard
- allow deleting top-up logs and program log files via web interface
- extend drinks management to handle minimum stock
- add DB update logic for new column and PIN

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_68810c088d848327a63efefd65e4ed57