### PR TITLE
Ensure database schema upgrades automatically

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -146,6 +146,36 @@ class PinDialog(QtWidgets.QDialog):
         return self.edit.text()
 
 
+class AdminPage(QtWidgets.QWidget):
+    """Simple admin page showing low stock items and quit option."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.table = QtWidgets.QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Getränk", "Bestand", "Min"])
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        layout.addWidget(self.table)
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        self.back_btn = QtWidgets.QPushButton("Zurück")
+        self.quit_btn = QtWidgets.QPushButton("Beenden")
+        btn_layout.addWidget(self.back_btn)
+        btn_layout.addStretch(1)
+        btn_layout.addWidget(self.quit_btn)
+        layout.addLayout(btn_layout)
+
+    def reload(self) -> None:
+        drinks = models.get_drinks_below_min()
+        self.table.setRowCount(len(drinks))
+        for row, drink in enumerate(drinks):
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(drink.name))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(drink.stock)))
+            self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(drink.min_stock)))
+
+
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
@@ -186,6 +216,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.info_label.setFont(font)
         self.stack.addWidget(self.info_label)
 
+        self.admin_page = AdminPage(self)
+        self.admin_page.back_btn.clicked.connect(self.show_start_page)
+        self.admin_page.quit_btn.clicked.connect(self._quit)
+        self.stack.addWidget(self.admin_page)
+
         self.show_start_page()
 
     def _populate_start_page(self) -> None:
@@ -199,7 +234,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         rows = (len(drinks) + 2) // 3
         for row in range(rows):
-            layout.setRowStretch(row, 1)
+            layout.setRowStretch(row, 0)
 
         for idx, drink in enumerate(drinks):
             button = QtWidgets.QPushButton()
@@ -230,7 +265,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.next_button.clicked.connect(self.next_page)
 
 
-        bottom = rows
+        spacer_row = rows
+        bottom = rows + 1
+        layout.setRowStretch(spacer_row, 1)
         layout.addWidget(self.prev_button, bottom, 0, alignment=QtCore.Qt.AlignBottom)
         layout.addWidget(self.next_button, bottom, 1, alignment=QtCore.Qt.AlignBottom)
 
@@ -243,8 +280,6 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addWidget(self.admin_button, bottom, 2,
                          alignment=QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight)
         layout.setRowStretch(bottom, 0)
-
-        layout.setRowStretch(bottom + 1, 1)
 
         self.prev_button.setEnabled(self.current_page > 1)
         self.next_button.setEnabled(self.current_page < self.page_count)
@@ -318,11 +353,14 @@ class MainWindow(QtWidgets.QMainWindow):
             self._rebuild_start_page()
 
     def _rebuild_start_page(self) -> None:
-        for i in reversed(range(self.start_layout.count())):
-            item = self.start_layout.takeAt(i)
+        layout = self.start_layout
+        for i in reversed(range(layout.count())):
+            item = layout.takeAt(i)
             widget = item.widget()
             if widget:
                 widget.deleteLater()
+        for r in range(layout.rowCount()):
+            layout.setRowStretch(r, 0)
         self._populate_start_page()
 
     def _handle_topup(self) -> None:
@@ -365,9 +403,14 @@ class MainWindow(QtWidgets.QMainWindow):
         if dialog.exec_() != QtWidgets.QDialog.Accepted:
             return
         if dialog.pin == models.get_admin_pin():
-            QtGui.QDesktopServices.openUrl(QtCore.QUrl("http://localhost:8000"))
+            self.admin_page.reload()
+            self.stack.setCurrentWidget(self.admin_page)
         else:
             QtWidgets.QMessageBox.warning(self, "Fehler", "Falscher PIN")
+
+    def _quit(self) -> None:
+        database.set_exit_flag()
+        QtWidgets.QApplication.quit()
 
     def next_page(self) -> None:
         if self.current_page < self.page_count:

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 set -e
 
+# Always operate relative to script location
+cd "$(dirname "$0")"
+
 # Pull latest changes if repository has remote
-if git rev-parse --git-dir > /dev/null 2>&1; then
-  git pull
+if git config --get remote.origin.url > /dev/null 2>&1; then
+  git pull --ff-only
+fi
+
+# Backup existing database
+DB_PATH="data/getraenkekasse.db"
+if [ -f "$DB_PATH" ]; then
+  cp "$DB_PATH" "$DB_PATH.bak.$(date +%s)"
 fi
 
 # Create venv if missing and install requirements
@@ -11,23 +20,14 @@ if [ ! -d venv ]; then
   python3 -m venv venv --system-site-packages
 fi
 source venv/bin/activate
-pip install -r requirements.txt
+pip install --upgrade pip setuptools wheel
+pip install --upgrade -r requirements.txt
 
 # Create any new database tables without touching existing data
 venv/bin/python - <<'PY'
 import src.database as d
 conn = d.get_connection()
 d.init_db(conn)
-cur = conn.execute("PRAGMA table_info(drinks)")
-cols = [r[1] for r in cur.fetchall()]
-if 'min_stock' not in cols:
-    conn.execute("ALTER TABLE drinks ADD COLUMN min_stock INTEGER NOT NULL DEFAULT 0")
-if 'page' not in cols:
-    conn.execute("ALTER TABLE drinks ADD COLUMN page INTEGER NOT NULL DEFAULT 1")
-cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='admin_pin'")
-if cur.fetchone()[0] == 0:
-    conn.execute("INSERT INTO config(key, value) VALUES ('admin_pin', '1234')")
-conn.commit()
 conn.close()
 PY
 


### PR DESCRIPTION
## Summary
- add `upgrade_schema()` to patch older DBs with missing columns and config
- invoke `upgrade_schema()` from `init_db`
- simplify `update.sh` to rely on in-app upgrade logic

## Testing
- `venv/bin/python -m py_compile $(git ls-files '*.py')`
- `bash update.sh` *(fails: cannot reach pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68839aaf249083278c4d3e1cc6b6157d