### PR TITLE
Implement log deletion per item and enforce drink page limit

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -171,7 +171,7 @@ def get_restock_log(limit: int | None = None) -> list[sqlite3.Row]:
     try:
         with get_connection() as conn:
             query = (
-                'SELECT r.timestamp, d.name as drink_name, r.quantity '
+                'SELECT r.id, r.timestamp, d.name as drink_name, r.quantity '
                 'FROM restocks r JOIN drinks d ON d.id = r.drink_id '
                 'ORDER BY r.timestamp DESC'
             )
@@ -205,7 +205,7 @@ def get_topup_log() -> list[sqlite3.Row]:
     try:
         with get_connection() as conn:
             cur = conn.execute(
-                'SELECT t.timestamp, u.name as user_name, t.amount '
+                'SELECT t.id, t.timestamp, u.name as user_name, t.amount '
                 'FROM topups t JOIN users u ON u.id = t.user_id '
                 'ORDER BY t.timestamp DESC'
             )

--- a/src/web/templates/drink_edit.html
+++ b/src/web/templates/drink_edit.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Getränk bearbeiten</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
 <form method="post" enctype="multipart/form-data">
     <label>Name:<br><input type="text" name="name" value="{{ drink['name'] }}"></label><br>
     <label>Preis in Euro:<br><input type="number" step="0.01" name="price" value="{{ (drink['price']/100)|round(2) }}"></label><br>

--- a/src/web/templates/drinks.html
+++ b/src/web/templates/drinks.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Getränke</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
 <table>
 
 <tr><th>Name</th><th>Preis</th><th>Lager</th><th>Mindestens</th><th>Seite</th><th>Auffüllen</th><th colspan="2">Aktion</th></tr>

--- a/src/web/templates/log.html
+++ b/src/web/templates/log.html
@@ -2,28 +2,35 @@
 {% block content %}
 <h1>Transaktionen</h1>
 <table>
-<tr><th>Zeitpunkt</th><th>Benutzer</th><th>Getränk</th><th>Menge</th></tr>
+<tr><th>Zeitpunkt</th><th>Benutzer</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in items %}
 <tr>
 <td>{{ r['timestamp'] }}</td>
 <td>{{ r['user_name'] }}</td>
 <td>{{ r['drink_name'] }}</td>
 <td>{{ r['quantity'] }}</td>
+<td>
+  <form method="post" action="{{ url_for('transaction_delete', tx_id=r['id']) }}" onsubmit="return confirm('Eintrag wirklich löschen?');">
+    <button type="submit">Löschen</button>
+  </form>
+</td>
 </tr>
 {% endfor %}
 </table>
-<form method="post" action="{{ url_for('log_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
-    <button type="submit">Log löschen</button>
-</form>
 
 <h2>Auffüllungen</h2>
 <table>
-<tr><th>Zeitpunkt</th><th>Getränk</th><th>Menge</th></tr>
+<tr><th>Zeitpunkt</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in restocks %}
 <tr>
 <td>{{ r['timestamp'] }}</td>
 <td>{{ r['drink_name'] }}</td>
 <td>{{ r['quantity'] }}</td>
+<td>
+  <form method="post" action="{{ url_for('restock_delete', restock_id=r['id']) }}" onsubmit="return confirm('Eintrag wirklich löschen?');">
+    <button type="submit">Löschen</button>
+  </form>
+</td>
 </tr>
 {% endfor %}
 </table>

--- a/src/web/templates/topup_log.html
+++ b/src/web/templates/topup_log.html
@@ -2,12 +2,17 @@
 {% block content %}
 <h1>Aufladungen</h1>
 <table>
-<tr><th>Zeitpunkt</th><th>Benutzer</th><th>Betrag</th></tr>
+<tr><th>Zeitpunkt</th><th>Benutzer</th><th>Betrag</th><th>Aktion</th></tr>
 {% for r in items %}
 <tr>
 <td>{{ r['timestamp'] }}</td>
 <td>{{ r['user_name'] }}</td>
 <td>{{ (r['amount']/100)|round(2) }} €</td>
+<td>
+  <form method="post" action="{{ url_for('topup_log_delete', entry_id=r['id']) }}" onsubmit="return confirm('Eintrag wirklich löschen?');">
+    <button type="submit">Löschen</button>
+  </form>
+</td>
 </tr>
 {% endfor %}
 </table>


### PR DESCRIPTION
## Summary
- allow deleting individual transactions, top-ups and restocks
- show delete button for each log entry in the admin web UI
- enforce a maximum of 9 drinks per page when adding or editing
- display error messages in drink management forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883a441dd7083279c159b393dfb7d96