### PR TITLE
Improve button colors for low stock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ zuverlässiger ohne AUTH-Fehler.
 
 Die GUI zeigt optional ein DRK-Logo im Hintergrund an. Lege dazu eine Bilddatei unter `data/background.png` ab. Ist diese Datei nicht vorhanden, wird kein Hintergrundbild angezeigt.
 
-Die Startseite zeigt maximal neun Getränke je Seite an. Über Pfeiltasten am unteren Rand lässt sich zwischen zwei Seiten wechseln. In den Getränkeeinstellungen kann mit dem neuen Feld "Seite" festgelegt werden, auf welcher Seite ein Artikel erscheint. Unterschreitet ein Getränk seinen Mindestbestand, wird der zugehörige Button in der GUI gelb hinterlegt.
+Die Startseite zeigt maximal neun Getränke je Seite an. Über Pfeiltasten am unteren Rand lässt sich zwischen zwei Seiten wechseln. In den Getränkeeinstellungen kann mit dem neuen Feld "Seite" festgelegt werden, auf welcher Seite ein Artikel erscheint. Unterschreitet ein Getränk seinen Mindestbestand, wird der zugehörige Button in der GUI gelb hinterlegt. Fällt der Lagerbestand unter 0, erscheint der Button deutlich rot und der Text wird ausgegraut.
 
 Zum Aufladen von Guthaben kann im Benutzerbereich eine UID gelesen und ein Betrag angegeben werden.
 Über die Einstellungen lässt sich zudem eine spezielle Aufladekarte definieren.

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -248,9 +248,9 @@ class MainWindow(QtWidgets.QMainWindow):
             button.setMinimumSize(220, 140)
 
             if drink.stock < 0:
-                button.setStyleSheet('background-color:#fdd;')
+                button.setStyleSheet('background-color:#f00; color:#888;')
             elif drink.stock < drink.min_stock:
-                button.setStyleSheet('background-color:#ffd;')
+                button.setStyleSheet('background-color:#ff0;')
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx, 3)
             layout.addWidget(button, r, c)


### PR DESCRIPTION
## Summary
- update color styles for beverage buttons
- document new red button behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884b7cce1248327a069f09944b9e6f5