### PR TITLE
Add monthly dashboard

### DIFF
--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -57,6 +57,19 @@ def create_app() -> Flask:
         return render_template('index.html', to_buy=to_buy)
 
 
+    @app.route('/dashboard')
+    @login_required
+    def dashboard():
+        stats, totals = models.get_monthly_stats()
+        return render_template('dashboard.html', stats=stats, totals=totals)
+
+    @app.route('/dashboard/receipt')
+    @login_required
+    def dashboard_receipt():
+        stats, totals = models.get_monthly_stats()
+        return render_template('dashboard_receipt.html', stats=stats, totals=totals)
+
+
     @app.route('/refresh', methods=['POST'])
     @login_required
     def refresh():

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -36,6 +36,7 @@
 <nav>
     <ul class="menu">
         <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
         <li class="dropdown"><a href="#">Getränke</a>
             <ul class="submenu">
                 <li><a href="{{ url_for('drinks') }}">Verwalten</a></li>

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<table>
+<tr>
+<th>Monat</th>
+<th>Einzahlungen</th>
+<th>Barkäufe Anzahl</th>
+<th>Barkäufe €</th>
+<th>Kartenkäufe Anzahl</th>
+<th>Kartenkäufe €</th>
+</tr>
+{% for r in stats %}
+<tr>
+<td>{{ r.month }}</td>
+<td>{{ (r.topup/100)|round(2) }} €</td>
+<td>{{ r.cash_count }}</td>
+<td>{{ (r.cash_value/100)|round(2) }} €</td>
+<td>{{ r.card_count }}</td>
+<td>{{ (r.card_value/100)|round(2) }} €</td>
+</tr>
+{% endfor %}
+</table>
+<p>Jahressumme Einzahlungen: {{ (totals.topup/100)|round(2) }} €</p>
+<p>Jahressumme Barkäufe: {{ totals.cash_count }} Stück / {{ (totals.cash_value/100)|round(2) }} €</p>
+<p>Jahressumme Kartenkäufe: {{ totals.card_count }} Stück / {{ (totals.card_value/100)|round(2) }} €</p>
+<p>Gesamt: {{ (totals.all_value/100)|round(2) }} €</p>
+<a href="{{ url_for('dashboard_receipt') }}" target="_blank">Quittung drucken</a>
+{% endblock %}

--- a/src/web/templates/dashboard_receipt.html
+++ b/src/web/templates/dashboard_receipt.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Jahresübersicht</h1>
+<table>
+<tr>
+<th>Monat</th>
+<th>Einzahlungen</th>
+<th>Barkäufe</th>
+<th>Kartenkäufe</th>
+</tr>
+{% for r in stats %}
+<tr>
+<td>{{ r.month }}</td>
+<td>{{ (r.topup/100)|round(2) }} €</td>
+<td>{{ r.cash_count }} / {{ (r.cash_value/100)|round(2) }} €</td>
+<td>{{ r.card_count }} / {{ (r.card_value/100)|round(2) }} €</td>
+</tr>
+{% endfor %}
+</table>
+<p>Jahressumme Einzahlungen: {{ (totals.topup/100)|round(2) }} €</p>
+<p>Jahressumme Barkäufe: {{ totals.cash_count }} Stück / {{ (totals.cash_value/100)|round(2) }} €</p>
+<p>Jahressumme Kartenkäufe: {{ totals.card_count }} Stück / {{ (totals.card_value/100)|round(2) }} €</p>
+<p>Gesamt: {{ (totals.all_value/100)|round(2) }} €</p>
+<script>window.print();</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- collect monthly deposit and purchase stats
- show new dashboard in admin web UI
- provide printable dashboard receipt

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884ba5f5ad483278b75a5d96febbff1