### PR TITLE
Add dashboard link and fix RFID import

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -4,7 +4,6 @@ import sqlite3
 
 from .database import get_connection, get_setting, set_setting
 
-from . import rfid
 
 # Maximum number of transactions to keep in the log
 MAX_TRANSACTIONS = 10000
@@ -293,5 +292,95 @@ def get_drinks_below_min(conn: Optional[sqlite3.Connection] = None) -> list[Drin
 
 def rfid_read_for_web() -> Optional[str]:
     """Read a UID for the web interface using the normal reader dialog."""
+    from . import rfid
+
     return rfid.read_uid()
+
+
+def _month_list(months: int) -> list[str]:
+    """Return a list of year-month strings for the last ``months`` months."""
+    from datetime import date
+
+    today = date.today()
+    res: list[str] = []
+    y = today.year
+    m = today.month
+    for _ in range(months):
+        res.append(f"{y:04d}-{m:02d}")
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    return list(reversed(res))
+
+
+def get_monthly_stats(months: int = 12) -> tuple[list[dict[str, int]], dict[str, int]]:
+    """Return statistics for the last ``months`` months."""
+    if months <= 0:
+        return [], {}
+
+    month_strings = _month_list(months)
+    start = month_strings[0] + "-01"
+
+    conn = get_connection()
+    try:
+        topup_rows = conn.execute(
+            "SELECT strftime('%Y-%m', timestamp) AS ym, "
+            "SUM(amount) AS total FROM topups WHERE timestamp >= ? "
+            "GROUP BY ym",
+            (start,),
+        ).fetchall()
+        topups = {row["ym"]: row["total"] for row in topup_rows}
+
+        cash_rows = conn.execute(
+            "SELECT strftime('%Y-%m', t.timestamp) AS ym, "
+            "SUM(t.quantity) AS cnt, "
+            "SUM(t.quantity * d.price) AS val "
+            "FROM transactions t "
+            "JOIN drinks d ON d.id = t.drink_id "
+            "JOIN users u ON u.id = t.user_id "
+            "WHERE u.name='BARZAHLUNG' AND t.timestamp >= ? "
+            "GROUP BY ym",
+            (start,),
+        ).fetchall()
+        cash = {row["ym"]: {"cnt": row["cnt"], "val": row["val"]} for row in cash_rows}
+
+        card_rows = conn.execute(
+            "SELECT strftime('%Y-%m', t.timestamp) AS ym, "
+            "SUM(t.quantity) AS cnt, "
+            "SUM(t.quantity * d.price) AS val "
+            "FROM transactions t "
+            "JOIN drinks d ON d.id = t.drink_id "
+            "JOIN users u ON u.id = t.user_id "
+            "WHERE u.name!='BARZAHLUNG' AND t.timestamp >= ? "
+            "GROUP BY ym",
+            (start,),
+        ).fetchall()
+        card = {row["ym"]: {"cnt": row["cnt"], "val": row["val"]} for row in card_rows}
+
+        stats: list[dict[str, int]] = []
+        totals = {
+            "topup": 0,
+            "cash_count": 0,
+            "cash_value": 0,
+            "card_count": 0,
+            "card_value": 0,
+        }
+        for ym in month_strings:
+            row = {
+                "month": ym,
+                "topup": int(topups.get(ym, 0) or 0),
+                "cash_count": int(cash.get(ym, {}).get("cnt", 0) or 0),
+                "cash_value": int(cash.get(ym, {}).get("val", 0) or 0),
+                "card_count": int(card.get(ym, {}).get("cnt", 0) or 0),
+                "card_value": int(card.get(ym, {}).get("val", 0) or 0),
+            }
+            for k in ("topup", "cash_count", "cash_value", "card_count", "card_value"):
+                totals[k] += row[k]
+            stats.append(row)
+
+        totals["all_value"] = totals["topup"] + totals["cash_value"] + totals["card_value"]
+        return stats, totals
+    finally:
+        conn.close()
 

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -57,6 +57,19 @@ def create_app() -> Flask:
         return render_template('index.html', to_buy=to_buy)
 
 
+    @app.route('/dashboard')
+    @login_required
+    def dashboard():
+        stats, totals = models.get_monthly_stats()
+        return render_template('dashboard.html', stats=stats, totals=totals)
+
+    @app.route('/dashboard/receipt')
+    @login_required
+    def dashboard_receipt():
+        stats, totals = models.get_monthly_stats()
+        return render_template('dashboard_receipt.html', stats=stats, totals=totals)
+
+
     @app.route('/refresh', methods=['POST'])
     @login_required
     def refresh():

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -36,6 +36,7 @@
 <nav>
     <ul class="menu">
         <li><a href="{{ url_for('index') }}">Home</a></li>
+        <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
         <li class="dropdown"><a href="#">Getränke</a>
             <ul class="submenu">
                 <li><a href="{{ url_for('drinks') }}">Verwalten</a></li>

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<table>
+<tr>
+<th>Monat</th>
+<th>Einzahlungen</th>
+<th>Barkäufe Anzahl</th>
+<th>Barkäufe €</th>
+<th>Kartenkäufe Anzahl</th>
+<th>Kartenkäufe €</th>
+</tr>
+{% for r in stats %}
+<tr>
+<td>{{ r.month }}</td>
+<td>{{ (r.topup/100)|round(2) }} €</td>
+<td>{{ r.cash_count }}</td>
+<td>{{ (r.cash_value/100)|round(2) }} €</td>
+<td>{{ r.card_count }}</td>
+<td>{{ (r.card_value/100)|round(2) }} €</td>
+</tr>
+{% endfor %}
+</table>
+<p>Jahressumme Einzahlungen: {{ (totals.topup/100)|round(2) }} €</p>
+<p>Jahressumme Barkäufe: {{ totals.cash_count }} Stück / {{ (totals.cash_value/100)|round(2) }} €</p>
+<p>Jahressumme Kartenkäufe: {{ totals.card_count }} Stück / {{ (totals.card_value/100)|round(2) }} €</p>
+<p>Gesamt: {{ (totals.all_value/100)|round(2) }} €</p>
+<a href="{{ url_for('dashboard_receipt') }}" target="_blank">Quittung drucken</a>
+{% endblock %}

--- a/src/web/templates/dashboard_receipt.html
+++ b/src/web/templates/dashboard_receipt.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Jahresübersicht</h1>
+<table>
+<tr>
+<th>Monat</th>
+<th>Einzahlungen</th>
+<th>Barkäufe</th>
+<th>Kartenkäufe</th>
+</tr>
+{% for r in stats %}
+<tr>
+<td>{{ r.month }}</td>
+<td>{{ (r.topup/100)|round(2) }} €</td>
+<td>{{ r.cash_count }} / {{ (r.cash_value/100)|round(2) }} €</td>
+<td>{{ r.card_count }} / {{ (r.card_value/100)|round(2) }} €</td>
+</tr>
+{% endfor %}
+</table>
+<p>Jahressumme Einzahlungen: {{ (totals.topup/100)|round(2) }} €</p>
+<p>Jahressumme Barkäufe: {{ totals.cash_count }} Stück / {{ (totals.cash_value/100)|round(2) }} €</p>
+<p>Jahressumme Kartenkäufe: {{ totals.card_count }} Stück / {{ (totals.card_value/100)|round(2) }} €</p>
+<p>Gesamt: {{ (totals.all_value/100)|round(2) }} €</p>
+<script>window.print();</script>
+{% endblock %}

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>Adminbereich</h1>
 <p>Willkommen!</p>
+<p><a href="{{ url_for('dashboard') }}">Dashboard</a></p>
 
 <form method="post" action="{{ url_for('refresh') }}">
     <button type="submit">GUI aktualisieren</button>


### PR DESCRIPTION
## Summary
- lazily import `rfid` inside `rfid_read_for_web` so the web server runs without PyQt5
- link to the dashboard from the admin home page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884ba5f5ad483278b75a5d96febbff1