### PR TITLE
Fix web UID reading without RFID reader

### DIFF
--- a/src/rfid.py
+++ b/src/rfid.py
@@ -25,7 +25,13 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
             QtWidgets.QMessageBox.warning(None, "RFID", "RFID-Reader nicht verfügbar")
         return None
 
-    reader = MFRC522()
+    try:
+        reader = MFRC522()
+    except Exception as e:  # pragma: no cover - hardware might be missing
+        print(f"RFID-Reader nicht verfügbar: {e}")
+        if show_dialog:
+            QtWidgets.QMessageBox.warning(None, "RFID", "RFID-Reader nicht verfügbar")
+        return None
     led.indicate_waiting()
 
     app = QtWidgets.QApplication.instance()

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -33,7 +33,9 @@ def create_app() -> Flask:
     @login_required
     def read_uid():
         uid = models.rfid_read_for_web()
-        return jsonify({'uid': uid or ''})
+        if uid is None:
+            return jsonify({'uid': '', 'error': 'RFID-Reader nicht verfügbar'})
+        return jsonify({'uid': uid})
 
     @app.route('/user_name')
     @login_required

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -17,6 +17,10 @@
 <script>
 function readUid(targetId){
     fetch('{{ url_for('read_uid') }}').then(r=>r.json()).then(data=>{
+        if(data.error){
+            alert(data.error);
+            return;
+        }
         document.getElementById(targetId).value = data.uid;
     });
 }

--- a/src/web/templates/topup.html
+++ b/src/web/templates/topup.html
@@ -24,6 +24,10 @@
 <script>
 function readUid(target){
     fetch('{{ url_for('read_uid') }}').then(r=>r.json()).then(d=>{
+        if(d.error){
+            alert(d.error);
+            return;
+        }
         document.getElementById(target).value=d.uid;
         if(target==='uid_scan') updateName();
     });

--- a/src/web/templates/user_edit.html
+++ b/src/web/templates/user_edit.html
@@ -11,6 +11,10 @@
 <script>
 function readUid(targetId) {
     fetch('{{ url_for('read_uid') }}').then(r => r.json()).then(data => {
+        if(data.error){
+            alert(data.error);
+            return;
+        }
         document.getElementById(targetId).value = data.uid;
     });
 }

--- a/src/web/templates/users.html
+++ b/src/web/templates/users.html
@@ -49,6 +49,10 @@ function updateName() {
 document.getElementById('uid_topup').addEventListener('change', updateName);
 function readUid(targetId) {
     fetch('{{ url_for('read_uid') }}').then(r => r.json()).then(data => {
+        if(data.error){
+            alert(data.error);
+            return;
+        }
         var el = document.getElementById(targetId);
         el.value = data.uid;
         if(targetId === 'uid_topup') updateName();


### PR DESCRIPTION
## Summary
- avoid crashing when RFID reader is missing
- disable GUI dialog for web UID reads
- return error message from `/read_uid`
- show alert in templates if an error occurs
- keep the normal dialog for regular use

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884c035b8a08327a62317eb9912e7b5