### PR TITLE
Improve button layout and colors

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -184,14 +184,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("Getränkekasse")
         self.resize(800, 480)
         self.central = QtWidgets.QWidget()
+        self.central.setObjectName("central_widget")
         self.setCentralWidget(self.central)
 
         logo_path = Path(__file__).resolve().parent.parent / 'data' / 'background.png'
         if logo_path.exists():
             self.central.setStyleSheet(
+                "#central_widget{"
                 f"background-image: url('{logo_path}');"
                 "background-repeat: no-repeat;"
                 "background-position: center;"
+                "}"
             )
 
         self.stack = QtWidgets.QStackedLayout(self.central)
@@ -245,30 +248,33 @@ class MainWindow(QtWidgets.QMainWindow):
                 button.setIcon(QtGui.QIcon(drink.image))
 
                 button.setIconSize(QtCore.QSize(120, 120))
-            button.setMinimumSize(220, 140)
+            button.setMinimumSize(220, 120)
 
+            style = 'background-color:#eee;'
             if drink.stock < 0:
-                button.setStyleSheet('background-color:#f00; color:#888;')
+                style = 'background-color:#f00; color:#888;'
             elif drink.stock < drink.min_stock:
-                button.setStyleSheet('background-color:#ff0;')
+                style = 'background-color:#ff0;'
+            button.setStyleSheet(style)
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx, 3)
             layout.addWidget(button, r, c)
         self.prev_button = QtWidgets.QPushButton("◀")
         self.next_button = QtWidgets.QPushButton("▶")
 
+        nav_size = QtCore.QSize(int(80 * 4 / 3), int(40 * 4 / 3))
         for btn in (self.prev_button, self.next_button):
             f = btn.font()
             f.setPointSize(20)
             btn.setFont(f)
-            btn.setFixedSize(80, 40)
+            btn.setFixedSize(nav_size)
         self.prev_button.clicked.connect(self.prev_page)
         self.next_button.clicked.connect(self.next_page)
 
 
         spacer_row = rows
         bottom = rows + 1
-        layout.setRowStretch(spacer_row, 1)
+        layout.setRowStretch(spacer_row, 0)
         layout.addWidget(self.prev_button, bottom, 0, alignment=QtCore.Qt.AlignBottom)
         layout.addWidget(self.next_button, bottom, 1, alignment=QtCore.Qt.AlignBottom)
 
@@ -276,7 +282,7 @@ class MainWindow(QtWidgets.QMainWindow):
         f = self.admin_button.font()
         f.setPointSize(12)
         self.admin_button.setFont(f)
-        self.admin_button.setFixedSize(80, 40)
+        self.admin_button.setFixedSize(nav_size)
         self.admin_button.clicked.connect(self._open_admin)
         layout.addWidget(self.admin_button, bottom, 2,
                          alignment=QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight)


### PR DESCRIPTION
## Summary
- set default drink button color to grey
- color drink buttons yellow below min stock and red when negative
- reduce drink button height and move navigation buttons up

## Testing
- `python -m py_compile src/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ed900b088327aa94ac242bc47161