### PR TITLE
Fix drink button coloring

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -246,15 +246,14 @@ class MainWindow(QtWidgets.QMainWindow):
             button.setFont(font)
             if drink.image:
                 button.setIcon(QtGui.QIcon(drink.image))
-
-                button.setIconSize(QtCore.QSize(120, 120))
+                button.setIconSize(QtCore.QSize(100, 100))
             button.setMinimumSize(220, 120)
 
-            style = 'background-color:#eee;'
+            style = 'QPushButton { background-color: #eee; }'
             if drink.stock < 0:
-                style = 'background-color:#f00; color:#888;'
+                style = 'QPushButton { background-color: #f00; color: #888; }'
             elif drink.stock < drink.min_stock:
-                style = 'background-color:#ff0;'
+                style = 'QPushButton { background-color: #ff0; }'
             button.setStyleSheet(style)
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx, 3)


### PR DESCRIPTION
## Summary
- show drink buttons with clear color states using QSS

## Testing
- `python3 -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6884f3881d84832796e6fe543d25d7f5