### PR TITLE
Fix button colors

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -250,12 +250,22 @@ class MainWindow(QtWidgets.QMainWindow):
                 button.setIconSize(QtCore.QSize(120, 120))
             button.setMinimumSize(220, 120)
 
-            style = 'background-color:#eee;'
+            bg_color = '#eee'
+            text_color: str | None = None
             if drink.stock < 0:
-                style = 'background-color:#f00; color:#888;'
+                bg_color = '#f00'
+                text_color = '#888'
             elif drink.stock < drink.min_stock:
-                style = 'background-color:#ff0;'
-            button.setStyleSheet(style)
+                bg_color = '#ff0'
+
+            # Set palette colors to ensure the button background is displayed
+            pal = button.palette()
+            pal.setColor(QtGui.QPalette.Button, QtGui.QColor(bg_color))
+            if text_color is not None:
+                pal.setColor(QtGui.QPalette.ButtonText, QtGui.QColor(text_color))
+            button.setAutoFillBackground(True)
+            button.setPalette(pal)
+            button.update()
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx, 3)
             layout.addWidget(button, r, c)


### PR DESCRIPTION
## Summary
- adjust drink buttons to set the background using palettes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884f672390883279802e2e172f5b612