### PR TITLE
Add dynamic button colors for low stock

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -250,22 +250,13 @@ class MainWindow(QtWidgets.QMainWindow):
                 button.setIconSize(QtCore.QSize(120, 120))
             button.setMinimumSize(220, 120)
 
-            bg_color = '#eee'
-            text_color: str | None = None
+            style = ""
             if drink.stock < 0:
-                bg_color = '#f00'
-                text_color = '#888'
+                style = "background-color: red; color: gray;"
             elif drink.stock < drink.min_stock:
-                bg_color = '#ff0'
+                style = "background-color: yellow;"
 
-            # Set palette colors to ensure the button background is displayed
-            pal = button.palette()
-            pal.setColor(QtGui.QPalette.Button, QtGui.QColor(bg_color))
-            if text_color is not None:
-                pal.setColor(QtGui.QPalette.ButtonText, QtGui.QColor(text_color))
-            button.setAutoFillBackground(True)
-            button.setPalette(pal)
-            button.update()
+            button.setStyleSheet(style)
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx, 3)
             layout.addWidget(button, r, c)


### PR DESCRIPTION
## Summary
- tint drink buttons red or yellow depending on stock levels
- use `setStyleSheet` to override the palette when a window stylesheet is set

## Testing
- `python3 -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6884fe354898832792420439f66eed54