### PR TITLE
Implement paginated views for logs

### DIFF
--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -19,6 +19,7 @@ from .. import database, models
 def create_app() -> Flask:
     app = Flask(__name__)
     app.secret_key = 'change-me'
+    PER_PAGE = 25
 
     def login_required(func):
         @wraps(func)
@@ -306,8 +307,20 @@ def create_app() -> Flask:
     @app.route('/topup_log')
     @login_required
     def topup_log():
-        items = models.get_topup_log()
-        return render_template('topup_log.html', items=items)
+        page = request.args.get('page', default=1, type=int)
+        conn = database.get_connection()
+        count = conn.execute('SELECT COUNT(*) FROM topups').fetchone()[0]
+        pages = max((count + PER_PAGE - 1) // PER_PAGE, 1)
+        offset = (page - 1) * PER_PAGE
+        cur = conn.execute(
+            'SELECT t.id, t.timestamp, u.name as user_name, t.amount '
+            'FROM topups t JOIN users u ON u.id = t.user_id '
+            'ORDER BY t.timestamp DESC LIMIT ? OFFSET ?',
+            (PER_PAGE, offset),
+        )
+        items = cur.fetchall()
+        conn.close()
+        return render_template('topup_log.html', items=items, page=page, pages=pages)
 
 
     @app.route('/topup_log/clear', methods=['POST'])
@@ -403,17 +416,42 @@ def create_app() -> Flask:
     @app.route('/log')
     @login_required
     def log():
+        tx_page = request.args.get('tx_page', default=1, type=int)
+        restock_page = request.args.get('restock_page', default=1, type=int)
+
         conn = database.get_connection()
+        tx_count = conn.execute('SELECT COUNT(*) FROM transactions').fetchone()[0]
+        tx_pages = max((tx_count + PER_PAGE - 1) // PER_PAGE, 1)
+        tx_offset = (tx_page - 1) * PER_PAGE
         cur = conn.execute(
             'SELECT t.id, t.timestamp, u.name as user_name, d.name as drink_name, t.quantity '
             'FROM transactions t '
             'JOIN users u ON u.id = t.user_id '
             'JOIN drinks d ON d.id = t.drink_id '
-            'ORDER BY t.timestamp DESC LIMIT 100')
+            'ORDER BY t.timestamp DESC LIMIT ? OFFSET ?',
+            (PER_PAGE, tx_offset),
+        )
         items = cur.fetchall()
-        restocks = models.get_restock_log(100)
+
+        restock_count = conn.execute('SELECT COUNT(*) FROM restocks').fetchone()[0]
+        restock_pages = max((restock_count + PER_PAGE - 1) // PER_PAGE, 1)
+        restock_offset = (restock_page - 1) * PER_PAGE
+        restocks = conn.execute(
+            'SELECT r.id, r.timestamp, d.name as drink_name, r.quantity '
+            'FROM restocks r JOIN drinks d ON d.id = r.drink_id '
+            'ORDER BY r.timestamp DESC LIMIT ? OFFSET ?',
+            (PER_PAGE, restock_offset),
+        ).fetchall()
         conn.close()
-        return render_template('log.html', items=items, restocks=restocks)
+        return render_template(
+            'log.html',
+            items=items,
+            restocks=restocks,
+            tx_page=tx_page,
+            tx_pages=tx_pages,
+            restock_page=restock_page,
+            restock_pages=restock_pages,
+        )
 
     @app.route('/log/transactions_clear', methods=['POST'])
     @login_required
@@ -578,11 +616,21 @@ def create_app() -> Flask:
     @app.route('/file_logs')
     @login_required
     def file_logs():
+        page = request.args.get('page', default=1, type=int)
         log_dir = Path(__file__).resolve().parents[1] / 'logs'
-        files = []
+        files: list[Path] = []
         if log_dir.exists():
-            files = sorted(log_dir.glob('log_*.txt'))
-        return render_template('file_logs.html', files=[f.name for f in files])
+            files = sorted(log_dir.glob('log_*.txt'), reverse=True)
+        total = len(files)
+        pages = max((total + PER_PAGE - 1) // PER_PAGE, 1)
+        start = (page - 1) * PER_PAGE
+        files = files[start : start + PER_PAGE]
+        return render_template(
+            'file_logs.html',
+            files=[f.name for f in files],
+            page=page,
+            pages=pages,
+        )
 
     @app.route('/file_logs/delete/<name>', methods=['POST'])
     @login_required

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -24,6 +24,9 @@
         .error { color:red; }
         .info { color:green; }
         .negstock { background:#fdd; }
+        .pagination { text-align:center; margin:0.5em 0; }
+        .pagination a { margin:0 0.5em; text-decoration:none; }
+        .pagination span { margin:0 0.5em; }
         @media(max-width:600px){
             nav ul { flex-direction:column; }
             nav .submenu { position:static; display:none; }

--- a/src/web/templates/file_logs.html
+++ b/src/web/templates/file_logs.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Programmlogs</h1>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('file_logs', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('file_logs', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 {% if files %}
 <table>
 <tr><th>Datei</th><th>Aktion</th></tr>
@@ -13,6 +22,15 @@
 </td></tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('file_logs', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('file_logs', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 {% else %}
 <p>Keine Logs vorhanden.</p>
 {% endif %}

--- a/src/web/templates/log.html
+++ b/src/web/templates/log.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Transaktionen</h1>
+<div class="pagination">
+{% if tx_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page-1, restock_page=restock_page) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ tx_page }} / {{ tx_pages }}</span>
+{% if tx_page < tx_pages %}
+<a href="{{ url_for('log', tx_page=tx_page+1, restock_page=restock_page) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Benutzer</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in items %}
@@ -17,12 +26,30 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if tx_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page-1, restock_page=restock_page) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ tx_page }} / {{ tx_pages }}</span>
+{% if tx_page < tx_pages %}
+<a href="{{ url_for('log', tx_page=tx_page+1, restock_page=restock_page) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('transactions_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>
 
 
 <h2>Auffüllungen</h2>
+<div class="pagination">
+{% if restock_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ restock_page }} / {{ restock_pages }}</span>
+{% if restock_page < restock_pages %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in restocks %}
@@ -38,6 +65,15 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if restock_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ restock_page }} / {{ restock_pages }}</span>
+{% if restock_page < restock_pages %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('restocks_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>

--- a/src/web/templates/topup_log.html
+++ b/src/web/templates/topup_log.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Aufladungen</h1>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('topup_log', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('topup_log', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Benutzer</th><th>Betrag</th><th>Aktion</th></tr>
 {% for r in items %}
@@ -16,6 +25,15 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('topup_log', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('topup_log', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('topup_log_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>


### PR DESCRIPTION
## Summary
- add constant `PER_PAGE` to admin server
- paginate transaction and restock logs
- paginate top-up log and file logs
- render pagination controls in log templates
- style pagination element in `base.html`

## Testing
- `python -m compileall -q src`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688744f1f6808327b96037e3b50eb9e7