### PR TITLE
Implement paginated views for logs

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -24,6 +24,9 @@
         .error { color:red; }
         .info { color:green; }
         .negstock { background:#fdd; }
+        .pagination { text-align:center; margin:0.5em 0; }
+        .pagination a { margin:0 0.5em; text-decoration:none; }
+        .pagination span { margin:0 0.5em; }
         @media(max-width:600px){
             nav ul { flex-direction:column; }
             nav .submenu { position:static; display:none; }

--- a/src/web/templates/file_logs.html
+++ b/src/web/templates/file_logs.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Programmlogs</h1>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('file_logs', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('file_logs', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 {% if files %}
 <table>
 <tr><th>Datei</th><th>Aktion</th></tr>
@@ -13,6 +22,15 @@
 </td></tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('file_logs', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('file_logs', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 {% else %}
 <p>Keine Logs vorhanden.</p>
 {% endif %}

--- a/src/web/templates/log.html
+++ b/src/web/templates/log.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Transaktionen</h1>
+<div class="pagination">
+{% if tx_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page-1, restock_page=restock_page) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ tx_page }} / {{ tx_pages }}</span>
+{% if tx_page < tx_pages %}
+<a href="{{ url_for('log', tx_page=tx_page+1, restock_page=restock_page) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Benutzer</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in items %}
@@ -17,12 +26,30 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if tx_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page-1, restock_page=restock_page) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ tx_page }} / {{ tx_pages }}</span>
+{% if tx_page < tx_pages %}
+<a href="{{ url_for('log', tx_page=tx_page+1, restock_page=restock_page) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('transactions_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>
 
 
 <h2>Auffüllungen</h2>
+<div class="pagination">
+{% if restock_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ restock_page }} / {{ restock_pages }}</span>
+{% if restock_page < restock_pages %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Getränk</th><th>Menge</th><th>Aktion</th></tr>
 {% for r in restocks %}
@@ -38,6 +65,15 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if restock_page > 1 %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ restock_page }} / {{ restock_pages }}</span>
+{% if restock_page < restock_pages %}
+<a href="{{ url_for('log', tx_page=tx_page, restock_page=restock_page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('restocks_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>

--- a/src/web/templates/topup_log.html
+++ b/src/web/templates/topup_log.html
@@ -1,6 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Aufladungen</h1>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('topup_log', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('topup_log', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <table>
 <tr><th>Zeitpunkt</th><th>Benutzer</th><th>Betrag</th><th>Aktion</th></tr>
 {% for r in items %}
@@ -16,6 +25,15 @@
 </tr>
 {% endfor %}
 </table>
+<div class="pagination">
+{% if page > 1 %}
+<a href="{{ url_for('topup_log', page=page-1) }}">&laquo; Zurück</a>
+{% endif %}
+<span>Seite {{ page }} / {{ pages }}</span>
+{% if page < pages %}
+<a href="{{ url_for('topup_log', page=page+1) }}">Weiter &raquo;</a>
+{% endif %}
+</div>
 <form method="post" action="{{ url_for('topup_log_clear') }}" onsubmit="return confirm('Log wirklich löschen?');">
     <button type="submit">Log löschen</button>
 </form>


### PR DESCRIPTION
## Summary
- add constant `PER_PAGE` to admin server
- paginate transaction and restock logs
- paginate top-up log and file logs
- render pagination controls in log templates
- style pagination element in `base.html`
- fix pagination queries for compatibility with older SQLite

## Testing
- `python -m compileall -q src`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688744f1f6808327b96037e3b50eb9e7