### PR TITLE
Use local Berlin time for log entries

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional
 import sqlite3
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from .database import get_connection, get_setting, set_setting
 
@@ -8,6 +10,14 @@ from . import rfid
 
 # Maximum number of transactions to keep in the log
 MAX_TRANSACTIONS = 10000
+
+
+LOCAL_TZ = ZoneInfo("Europe/Berlin")
+
+
+def _now() -> str:
+    """Return the current local time as ISO string."""
+    return datetime.now(LOCAL_TZ).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def get_overdraft_limit(conn: Optional[sqlite3.Connection] = None) -> int:
@@ -102,8 +112,10 @@ def add_transaction(user_id: int, drink_id: int, quantity: int) -> None:
     try:
         with get_connection() as conn:
             conn.execute(
-                'INSERT INTO transactions (user_id, drink_id, quantity) VALUES (?, ?, ?)',
-                (user_id, drink_id, quantity))
+                'INSERT INTO transactions (user_id, drink_id, quantity, timestamp) '
+                'VALUES (?, ?, ?, ?)',
+                (user_id, drink_id, quantity, _now()),
+            )
             conn.execute(
                 'DELETE FROM transactions WHERE id NOT IN ('
                 'SELECT id FROM transactions ORDER BY id DESC LIMIT ?)',
@@ -159,8 +171,9 @@ def log_restock(drink_id: int, quantity: int) -> None:
     try:
         with get_connection() as conn:
             conn.execute(
-                'INSERT INTO restocks (drink_id, quantity) VALUES (?, ?)',
-                (drink_id, quantity),
+                'INSERT INTO restocks (drink_id, quantity, timestamp) '
+                'VALUES (?, ?, ?)',
+                (drink_id, quantity, _now()),
             )
             conn.commit()
     except sqlite3.Error as e:  # pragma: no cover - DB failure
@@ -189,8 +202,9 @@ def add_topup(user_id: int, amount: int) -> None:
     try:
         with get_connection() as conn:
             conn.execute(
-                'INSERT INTO topups (user_id, amount) VALUES (?, ?)',
-                (user_id, amount),
+                'INSERT INTO topups (user_id, amount, timestamp) '
+                'VALUES (?, ?, ?)',
+                (user_id, amount, _now()),
             )
             conn.execute(
                 'DELETE FROM topups WHERE id NOT IN ('


### PR DESCRIPTION
## Summary
- set a Berlin timezone constant
- generate timestamps with the local timezone

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68877af4d26c8327bdfd6a2e1da2832c