### PR TITLE
RFID Admin login and event card rename

### DIFF
--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <backup-file>" >&2
+  exit 1
+fi
+
+python3 - "$1" <<'PY'
+import sys
+from pathlib import Path
+import src.database as d
+
+backup = Path(sys.argv[1])
+d.restore_database(backup)
+print(f"Restored database from {backup}")
+PY
+

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -113,15 +113,11 @@ def create_app() -> Flask:
     def settings():
         conn = database.get_connection()
         current_limit = models.get_overdraft_limit(conn)
-        current_topup = models.get_topup_uid(conn) or ''
         current_pin = models.get_admin_pin(conn)
         if request.method == 'POST':
             val = request.form.get('overdraft', type=float)
             if val is not None:
                 models.set_overdraft_limit(int(val * 100), conn)
-            topup_uid = request.form.get('topup_uid')
-            if topup_uid is not None:
-                models.set_topup_uid(topup_uid, conn)
             pin_val = request.form.get('admin_pin')
             if pin_val is not None:
                 models.set_admin_pin(pin_val, conn)
@@ -129,7 +125,6 @@ def create_app() -> Flask:
             return redirect(url_for('settings'))
         conn.close()
         return render_template('settings.html', overdraft_limit=current_limit,
-                               topup_uid=current_topup,
                                admin_pin=current_pin)
 
 
@@ -266,25 +261,25 @@ def create_app() -> Flask:
     @login_required
     def users(error: Optional[str] = None):
         conn = database.get_connection()
-        cur = conn.execute('SELECT * FROM users WHERE is_invoice=0 ORDER BY name')
+        cur = conn.execute('SELECT * FROM users WHERE is_event=0 ORDER BY name')
         items = cur.fetchall()
         conn.close()
         return render_template('users.html', users=items, error=error)
 
-    @app.route('/invoice_users')
+    @app.route('/event_cards')
     @login_required
-    def invoice_users(error: Optional[str] = None):
+    def event_cards(error: Optional[str] = None):
         conn = database.get_connection()
-        cur = conn.execute('SELECT * FROM users WHERE is_invoice=1 ORDER BY name')
+        cur = conn.execute('SELECT * FROM users WHERE is_event=1 ORDER BY name')
         items = cur.fetchall()
         conn.close()
-        return render_template('invoice_users.html', users=items, error=error)
+        return render_template('event_cards.html', users=items, error=error)
 
     @app.route('/topup')
     @login_required
     def topup():
         conn = database.get_connection()
-        cur = conn.execute('SELECT id, name FROM users WHERE is_invoice=0 ORDER BY name')
+        cur = conn.execute('SELECT id, name FROM users WHERE is_event=0 ORDER BY name')
         items = cur.fetchall()
         conn.close()
         return render_template('topup.html', users=items)
@@ -370,15 +365,15 @@ def create_app() -> Flask:
                 conn.close()
         if error:
             conn = database.get_connection()
-            cur = conn.execute('SELECT * FROM users WHERE is_invoice=0 ORDER BY name')
+            cur = conn.execute('SELECT * FROM users WHERE is_event=0 ORDER BY name')
             items = cur.fetchall()
             conn.close()
             return render_template('users.html', users=items, error=error)
         return redirect(url_for('users'))
 
-    @app.route('/invoice_users/add', methods=['POST'])
+    @app.route('/event_cards/add', methods=['POST'])
     @login_required
-    def invoice_user_add():
+    def event_card_add():
         name = request.form.get('name')
         uid = request.form.get('uid')
         show_on_payment = 1 if request.form.get('show_on_payment') else 0
@@ -387,7 +382,7 @@ def create_app() -> Flask:
             conn = database.get_connection()
             try:
                 conn.execute(
-                    'INSERT INTO users (name, rfid_uid, balance, is_invoice, active, show_on_payment) VALUES (?, ?, 0, 1, 1, ?)',
+                    'INSERT INTO users (name, rfid_uid, balance, is_event, active, show_on_payment) VALUES (?, ?, 0, 1, 1, ?)',
                     (name, uid, show_on_payment),
                 )
                 conn.commit()
@@ -397,11 +392,11 @@ def create_app() -> Flask:
                 conn.close()
         if error:
             conn = database.get_connection()
-            cur = conn.execute('SELECT * FROM users WHERE is_invoice=1 ORDER BY name')
+            cur = conn.execute('SELECT * FROM users WHERE is_event=1 ORDER BY name')
             items = cur.fetchall()
             conn.close()
-            return render_template('invoice_users.html', users=items, error=error)
-        return redirect(url_for('invoice_users'))
+            return render_template('event_cards.html', users=items, error=error)
+        return redirect(url_for('event_cards'))
 
 
     @app.route('/users/topup', methods=['POST'])
@@ -430,25 +425,25 @@ def create_app() -> Flask:
         conn.close()
         return redirect(url_for('users'))
 
-    @app.route('/invoice_users/delete/<int:user_id>')
+    @app.route('/event_cards/delete/<int:user_id>')
     @login_required
-    def invoice_user_delete(user_id: int):
+    def event_card_delete(user_id: int):
         conn = database.get_connection()
-        conn.execute('DELETE FROM users WHERE id = ? AND is_invoice=1', (user_id,))
+        conn.execute('DELETE FROM users WHERE id = ? AND is_event=1', (user_id,))
         conn.commit()
         conn.close()
-        return redirect(url_for('invoice_users'))
+        return redirect(url_for('event_cards'))
 
-    @app.route('/invoice_users/print/<int:user_id>')
+    @app.route('/event_cards/print/<int:user_id>')
     @login_required
-    def invoice_user_print(user_id: int):
+    def event_card_print(user_id: int):
         conn = database.get_connection()
         user = conn.execute(
-            'SELECT * FROM users WHERE id=? AND is_invoice=1', (user_id,)
+            'SELECT * FROM users WHERE id=? AND is_event=1', (user_id,)
         ).fetchone()
         if not user:
             conn.close()
-            return redirect(url_for('invoice_users'))
+            return redirect(url_for('event_cards'))
         cur = conn.execute(
             'SELECT t.timestamp, d.name, t.quantity, d.price '
             'FROM transactions t JOIN drinks d ON d.id = t.drink_id '
@@ -458,7 +453,7 @@ def create_app() -> Flask:
         items = cur.fetchall()
         conn.close()
         total = sum(r['quantity'] * r['price'] for r in items)
-        return render_template('invoice_print.html', user=user, items=items, total=total)
+        return render_template('event_print.html', user=user, items=items, total=total)
 
     @app.route('/users/edit/<int:user_id>', methods=['GET', 'POST'])
     @login_required
@@ -468,24 +463,26 @@ def create_app() -> Flask:
             name = request.form.get('name')
             uid = request.form.get('uid')
             balance_euro = request.form.get('balance', type=float)
-            is_invoice = 1 if request.form.get('is_invoice') else 0
+            is_event = 1 if request.form.get('is_event') else 0
+            is_admin = 1 if request.form.get('is_admin') else 0
             active = 1 if request.form.get('active') else 0
-            show_on_payment = 1 if request.form.get('show_on_payment') and is_invoice else 0
+            show_on_payment = 1 if request.form.get('show_on_payment') and is_event else 0
             conn.execute(
-                'UPDATE users SET name=?, rfid_uid=?, balance=?, is_invoice=?, active=?, show_on_payment=? WHERE id=?',
+                'UPDATE users SET name=?, rfid_uid=?, balance=?, is_event=?, active=?, show_on_payment=?, is_admin=? WHERE id=?',
                 (
                     name,
                     uid,
                     int(balance_euro * 100) if balance_euro is not None else 0,
-                    is_invoice,
+                    is_event,
                     active,
                     show_on_payment,
+                    is_admin,
                     user_id,
                 ),
             )
             conn.commit()
             conn.close()
-            return redirect(url_for('invoice_users' if is_invoice else 'users'))
+            return redirect(url_for('event_cards' if is_event else 'users'))
         cur = conn.execute('SELECT * FROM users WHERE id=?', (user_id,))
         item = cur.fetchone()
         conn.close()

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -50,7 +50,7 @@
         <li class="dropdown"><a href="#">Benutzer</a>
             <ul class="submenu">
                   <li><a href="{{ url_for('users') }}">Verwalten</a></li>
-                  <li><a href="{{ url_for('invoice_users') }}">Rechnungskarten</a></li>
+                  <li><a href="{{ url_for('event_cards') }}">Veranstaltungskarten</a></li>
                   <li><a href="{{ url_for('topup') }}">Aufladen</a></li>
                 <li><a href="{{ url_for('topup_log') }}">Aufladungen</a></li>
                 <li><a href="{{ url_for('export_topups') }}">CSV Aufladungen</a></li>

--- a/src/web/templates/event_cards.html
+++ b/src/web/templates/event_cards.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Rechnungskarten</h1>
+<h1>Veranstaltungskarten</h1>
 {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
 <table>
 <tr><th>Firma</th><th>UID</th><th>Guthaben</th><th>Aktiv</th><th>Zahlungsmethoden</th><th colspan="3">Aktion</th></tr>
@@ -11,14 +11,14 @@
 <td>{{ (u['balance']/100)|round(2) }} €</td>
 <td>{{ 'ja' if u['active'] else 'nein' }}</td>
 <td>{{ 'ja' if u['show_on_payment'] else 'nein' }}</td>
-<td><a href="{{ url_for('invoice_user_print', user_id=u['id']) }}" target="_blank">Druck</a></td>
+<td><a href="{{ url_for('event_card_print', user_id=u['id']) }}" target="_blank">Druck</a></td>
 <td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
-<td><a href="{{ url_for('invoice_user_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
+<td><a href="{{ url_for('event_card_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
 </tr>
 {% endfor %}
 </table>
 <h2>Neu</h2>
-<form method="post" action="{{ url_for('invoice_user_add') }}">
+<form method="post" action="{{ url_for('event_card_add') }}">
     <input type="text" name="name" placeholder="Firmenname">
     <input type="text" name="uid" id="uid_new" placeholder="UID">
     <label><input type="checkbox" name="show_on_payment" value="1"> Auf Zahlungsmethoden anzeigen</label>

--- a/src/web/templates/event_print.html
+++ b/src/web/templates/event_print.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Rechnung für {{ user['name'] }}</h1>
+<h1>Veranstaltung für {{ user['name'] }}</h1>
 <table>
 <tr><th>Zeit</th><th>Artikel</th><th>Menge</th><th>Preis</th><th>Summe</th></tr>
 {% for i in items %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -5,24 +5,9 @@
     <label>Überziehungslimit in Euro:<br>
         <input type="number" step="0.01" name="overdraft" value="{{ overdraft_limit/100 }}">
     </label><br>
-    <label>UID der Aufladekarte:<br>
-        <input type="text" name="topup_uid" id="topup_uid" value="{{ topup_uid }}">
-    </label>
-    <button type="button" onclick="readUid('topup_uid')">UID lesen</button><br>
     <label>Admin-PIN:<br>
         <input type="text" name="admin_pin" value="{{ admin_pin }}">
     </label><br>
     <button type="submit">Speichern</button>
 </form>
-<script>
-function readUid(targetId){
-    fetch('{{ url_for('read_uid') }}').then(r=>r.json()).then(data=>{
-        if(data.error){
-            alert(data.error);
-            return;
-        }
-        document.getElementById(targetId).value = data.uid;
-    });
-}
-</script>
 {% endblock %}

--- a/src/web/templates/user_edit.html
+++ b/src/web/templates/user_edit.html
@@ -6,10 +6,11 @@
     <label>UID:<br><input type="text" name="uid" id="uid_edit" value="{{ user['rfid_uid'] }}"></label>
     <button type="button" onclick="readUid('uid_edit')">UID lesen</button><br>
       <label>Guthaben in Euro:<br><input type="number" step="0.01" name="balance" value="{{ (user['balance']/100)|round(2) }}"></label><br>
-        <label><input type="checkbox" name="is_invoice" value="1" {% if user['is_invoice'] %}checked{% endif %}> Rechnungskarte</label><br>
-        {% if user['is_invoice'] %}
+        <label><input type="checkbox" name="is_event" value="1" {% if user['is_event'] %}checked{% endif %}> Veranstaltungskarte</label><br>
+        {% if user['is_event'] %}
         <label><input type="checkbox" name="show_on_payment" value="1" {% if user['show_on_payment'] %}checked{% endif %}> Auf Zahlungsmethoden anzeigen</label><br>
         {% endif %}
+        <label><input type="checkbox" name="is_admin" value="1" {% if user['is_admin'] %}checked{% endif %}> Adminzugang</label><br>
       <label><input type="checkbox" name="active" value="1" {% if user['active'] %}checked{% endif %}> Aktiv</label><br>
       <button type="submit">Speichern</button>
   </form>

--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,10 @@ fi
 # Backup existing database
 DB_PATH="data/getraenkekasse.db"
 if [ -f "$DB_PATH" ]; then
-  cp "$DB_PATH" "$DB_PATH.bak.$(date +%s)"
+  python3 - <<'PY'
+import src.database as d
+d.backup_database()
+PY
 fi
 
 # Create venv if missing and install requirements


### PR DESCRIPTION
## Summary
- Authenticate admin GUI via RFID and user admin flag
- Add touch-friendly admin menu with stock warnings and account top-up
- Rename invoice cards to event cards across app and web interface
- Remove PIN login and top-up card configuration
- Bold quantity selection label
- Rotate database backups and add restore helper script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ba38831883279db493576fdc3c07