### PR TITLE
fix: rename QuantityDialog event handler to avoid Qt conflict

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -68,7 +68,7 @@ class QuantityDialog(QtWidgets.QDialog):
         self._event_user_id: int | None = None
         for user in models.get_event_payment_users():
             btn = QtWidgets.QPushButton(user.name)
-            btn.clicked.connect(lambda _, uid=user.id: self.event(uid))
+            btn.clicked.connect(lambda _, uid=user.id: self._select_event_user(uid))
             buttons.append(btn)
 
         for i, btn in enumerate(buttons):
@@ -108,7 +108,8 @@ class QuantityDialog(QtWidgets.QDialog):
         self._cash = True
         self.accept()
 
-    def event(self, uid: int) -> None:
+    def _select_event_user(self, uid: int) -> None:
+        """Store the selected event user's id and close the dialog."""
         self._event_user_id = uid
         self.accept()
 


### PR DESCRIPTION
## Summary
- rename custom `event` handler to `_select_event_user` to avoid overriding Qt's `event`
- add docstring and update button connections

## Testing
- `python -m py_compile src/gui/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c1a4df308327b7c4c0f086df6e5b