### PR TITLE
Add web interface QR code upload and status tab

### DIFF
--- a/src/gui/admin_window.py
+++ b/src/gui/admin_window.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtCore, QtWidgets, QtGui
+from pathlib import Path
+import platform
 
 from .. import database
 from .. import models
@@ -17,6 +19,10 @@ class AdminWindow(QtWidgets.QWidget):
         self._setup_users_tab()
         self._setup_drinks_tab()
         self._setup_log_tab()
+        self._setup_status_tab()
+        self.web_button = QtWidgets.QPushButton("Webinterface")
+        self.web_button.clicked.connect(self.show_web_qr)
+        layout.addWidget(self.web_button)
 
     def _setup_users_tab(self):
         widget = QtWidgets.QWidget()
@@ -71,3 +77,35 @@ class AdminWindow(QtWidgets.QWidget):
             self.log_list.addItem(
                 f"{row['timestamp']} - {row['user_name']} kaufte {row['quantity']} x {row['drink_name']}" )
         conn.close()
+
+    def _setup_status_tab(self):
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(widget)
+        self.tabs.addTab(widget, "Status")
+        self.status_label = QtWidgets.QLabel()
+        layout.addWidget(self.status_label)
+        self.reload_status()
+
+    def reload_status(self):
+        conn = database.get_connection()
+        users = conn.execute('SELECT COUNT(*) FROM users').fetchone()[0]
+        drinks = conn.execute('SELECT COUNT(*) FROM drinks').fetchone()[0]
+        conn.close()
+        system = platform.platform()
+        self.status_label.setText(
+            f"Nutzer: {users}\nGetränke: {drinks}\nSystem: {system}")
+
+    def show_web_qr(self):
+        data_dir = Path(__file__).resolve().parent.parent / 'data'
+        path = data_dir / 'web_qr.png'
+        if not path.exists():
+            QtWidgets.QMessageBox.warning(self, "Fehler", "Kein QR-Code vorhanden.")
+            return
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowTitle("Webinterface QR-Code")
+        pixmap = QtGui.QPixmap(str(path))
+        label = QtWidgets.QLabel()
+        label.setPixmap(pixmap)
+        layout = QtWidgets.QVBoxLayout(dlg)
+        layout.addWidget(label)
+        dlg.exec_()

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -1,13 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Einstellungen</h1>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
     <label>Überziehungslimit in Euro:<br>
         <input type="number" step="0.01" name="overdraft" value="{{ overdraft_limit/100 }}">
     </label><br>
     <label>Admin-PIN:<br>
         <input type="text" name="admin_pin" value="{{ admin_pin }}">
     </label><br>
+    <label>Webinterface QR-Code:<br>
+        <input type="file" name="qr_code" accept="image/png">
+    </label><br>
+    {% if qr_code_exists %}
+    <img src="{{ url_for('web_qr_png') }}" alt="QR-Code" style="max-width:200px;"><br>
+    {% endif %}
     <button type="submit">Speichern</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show QR code for web interface in admin GUI via dedicated button
- Allow uploading a new QR PNG in web settings and serve it for display
- Add status tab to admin GUI with basic system information

## Testing
- `python -m py_compile src/gui/admin_window.py src/web/admin_server.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894dc9a72348327a79914fb5ec08e2b