### PR TITLE
Display total user balance on admin index

### DIFF
--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -56,8 +56,12 @@ def create_app() -> Flask:
             return redirect(url_for('login'))
         conn = database.get_connection()
         to_buy = models.get_drinks_below_min(conn)
+        row = conn.execute(
+            'SELECT COALESCE(SUM(balance), 0) AS total FROM users WHERE is_event=0'
+        ).fetchone()
+        total_balance = row['total'] if row else 0
         conn.close()
-        return render_template('index.html', to_buy=to_buy)
+        return render_template('index.html', to_buy=to_buy, total_balance=total_balance)
 
 
     @app.route('/dashboard')

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3,6 +3,9 @@
 <h1>Adminbereich</h1>
 <p>Willkommen!</p>
 
+<p>Guthaben aller Benutzer (ohne Veranstaltungskarten):
+   {{ (total_balance/100)|round(2) }} €</p>
+
 <form method="post" action="{{ url_for('refresh') }}">
     <button type="submit">GUI aktualisieren</button>
 </form>


### PR DESCRIPTION
## Summary
- show total balance of all non-event users on admin start page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68975e904fc08327909ef302a5cb3405