### PR TITLE
feat: allow thank page background

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ zuverlässiger ohne AUTH-Fehler.
 
    Über die Startseite lässt sich die GUI mittels "GUI aktualisieren" neu laden, falls Getränke geändert wurden.
 
-Die GUI zeigt optional ein DRK-Logo im Hintergrund an. Lege dazu eine Bilddatei unter `data/background.png` ab. Ist diese Datei nicht vorhanden, wird kein Hintergrundbild angezeigt.
+Die GUI zeigt optional Hintergrundbilder. Über den Web-Admin unter "Einstellungen" lassen sich Bilder für Start- und Dankesseite hochladen. Die Dateien werden als `data/background.png` bzw. `data/background_thanks.png` gespeichert. Ist eine Datei nicht vorhanden, wird kein Bild angezeigt.
 
 Die Startseite zeigt maximal neun Getränke je Seite an. Über Pfeiltasten am unteren Rand lässt sich zwischen zwei Seiten wechseln. In den Getränkeeinstellungen kann mit dem neuen Feld "Seite" festgelegt werden, auf welcher Seite ein Artikel erscheint. Unterschreitet ein Getränk seinen Mindestbestand, wird der zugehörige Button in der GUI gelb hinterlegt. Fällt der Lagerbestand unter 0, erscheint der Button deutlich rot und der Text wird ausgegraut.
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -419,15 +419,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.central.setObjectName("central_widget")
         self.setCentralWidget(self.central)
 
-        logo_path = Path(__file__).resolve().parent.parent / 'data' / 'background.png'
-        if logo_path.exists():
-            self.central.setStyleSheet(
-                "#central_widget{"
-                f"background-image: url('{logo_path}');"
-                "background-repeat: no-repeat;"
-                "background-position: center;"
-                "}"
-            )
+        data_dir = Path(__file__).resolve().parent.parent / 'data'
+        self._default_bg = data_dir / 'background.png'
+        self._thank_bg = data_dir / 'background_thanks.png'
+        self._apply_background(self._default_bg)
 
         self.stack = QtWidgets.QStackedLayout(self.central)
 
@@ -474,6 +469,18 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stack.addWidget(self.event_card_page)
 
         self.show_start_page()
+
+    def _apply_background(self, path: Path) -> None:
+        if path and path.exists():
+            self.central.setStyleSheet(
+                "#central_widget{"\
+                f"background-image: url('{path}');"\
+                "background-repeat: no-repeat;"\
+                "background-position: center;"\
+                "}"
+            )
+        else:
+            self.central.setStyleSheet("")
 
     def _populate_start_page(self) -> None:
         layout = self.start_layout
@@ -547,6 +554,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.next_button.setEnabled(self.current_page < self.page_count)
 
     def show_start_page(self):
+        self._apply_background(self._default_bg)
         self.stack.setCurrentWidget(self.start_page)
 
     def show_admin_menu(self) -> None:
@@ -662,6 +670,8 @@ class MainWindow(QtWidgets.QMainWindow):
             models.update_drink_stock(drink.id, -quantity)
             models.add_transaction(user.id, drink.id, quantity)
             led.indicate_success()
+            if self._thank_bg.exists():
+                self._apply_background(self._thank_bg)
             self.info_label.setText(
                 f"Danke {user.name}!\nKauf wird verbucht."
             )
@@ -691,6 +701,8 @@ class MainWindow(QtWidgets.QMainWindow):
         models.add_transaction(user.id, drink.id, quantity)
         new_user = models.get_user_by_uid(uid)
         led.indicate_success()
+        if self._thank_bg.exists():
+            self._apply_background(self._thank_bg)
         msg = (
             f"Danke {new_user.name}!\nAltes Guthaben: {old_balance/100:.2f} €\n"
             f"Neues Guthaben: {new_user.balance/100:.2f} €"

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -118,7 +118,10 @@ def create_app() -> Flask:
         conn = database.get_connection()
         current_limit = models.get_overdraft_limit(conn)
         current_pin = models.get_admin_pin(conn)
-        qr_path = Path(__file__).resolve().parent.parent / 'data' / 'web_qr.png'
+        data_dir = Path(__file__).resolve().parent.parent / 'data'
+        qr_path = data_dir / 'web_qr.png'
+        bg_path = data_dir / 'background.png'
+        thank_path = data_dir / 'background_thanks.png'
         if request.method == 'POST':
             val = request.form.get('overdraft', type=float)
             if val is not None:
@@ -128,20 +131,45 @@ def create_app() -> Flask:
                 models.set_admin_pin(pin_val, conn)
             qr_file = request.files.get('qr_code')
             if qr_file and qr_file.filename:
-                data_dir = qr_path.parent
                 data_dir.mkdir(parents=True, exist_ok=True)
                 qr_file.save(qr_path)
+            bg_file = request.files.get('background')
+            if bg_file and bg_file.filename:
+                data_dir.mkdir(parents=True, exist_ok=True)
+                bg_file.save(bg_path)
+            thank_file = request.files.get('thank_background')
+            if thank_file and thank_file.filename:
+                data_dir.mkdir(parents=True, exist_ok=True)
+                thank_file.save(thank_path)
             conn.close()
             return redirect(url_for('settings'))
         conn.close()
         return render_template('settings.html', overdraft_limit=current_limit,
                                admin_pin=current_pin,
-                               qr_code_exists=qr_path.exists())
+                               qr_code_exists=qr_path.exists(),
+                               background_exists=bg_path.exists(),
+                               thank_background_exists=thank_path.exists())
 
     @app.route('/web_qr.png')
     @login_required
     def web_qr_png():
         path = Path(__file__).resolve().parent.parent / 'data' / 'web_qr.png'
+        if path.exists():
+            return send_file(path)
+        return ('', 404)
+
+    @app.route('/background.png')
+    @login_required
+    def background_png():
+        path = Path(__file__).resolve().parent.parent / 'data' / 'background.png'
+        if path.exists():
+            return send_file(path)
+        return ('', 404)
+
+    @app.route('/thank_background.png')
+    @login_required
+    def thank_background_png():
+        path = Path(__file__).resolve().parent.parent / 'data' / 'background_thanks.png'
         if path.exists():
             return send_file(path)
         return ('', 404)

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -14,6 +14,18 @@
     {% if qr_code_exists %}
     <img src="{{ url_for('web_qr_png') }}" alt="QR-Code" style="max-width:200px;"><br>
     {% endif %}
+    <label>Hintergrundbild:<br>
+        <input type="file" name="background" accept="image/png">
+    </label><br>
+    {% if background_exists %}
+    <img src="{{ url_for('background_png') }}" alt="Hintergrund" style="max-width:200px;"><br>
+    {% endif %}
+    <label>Hintergrundbild Dankesseite:<br>
+        <input type="file" name="thank_background" accept="image/png">
+    </label><br>
+    {% if thank_background_exists %}
+    <img src="{{ url_for('thank_background_png') }}" alt="Danke-Hintergrund" style="max-width:200px;"><br>
+    {% endif %}
     <button type="submit">Speichern</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- let GUI show optional separate background for thank-you screen
- add settings fields to upload generic and thank-you backgrounds
- document new image support in README

## Testing
- `python -m py_compile src/gui/main_window.py src/web/admin_server.py`


------
https://chatgpt.com/codex/tasks/task_e_689b458a27f883279ad262640a5ac919