### PR TITLE
Add anonymized sales CSV export

### DIFF
--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -634,6 +634,29 @@ def create_app() -> Flask:
         resp.headers['Content-Disposition'] = 'attachment; filename=transactions.csv'
         return resp
 
+    @app.route('/export/transactions_anonymized')
+    @login_required
+    def export_transactions_anonymized():
+        conn = database.get_connection()
+        cur = conn.execute(
+            'SELECT d.name as drink_name FROM transactions t '
+            'JOIN drinks d ON d.id = t.drink_id '
+            'ORDER BY t.timestamp DESC'
+        )
+        rows = cur.fetchall()
+        conn.close()
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['drink'])
+        for r in rows:
+            writer.writerow([r['drink_name']])
+        resp = make_response(out.getvalue())
+        resp.headers['Content-Type'] = 'text/csv'
+        resp.headers['Content-Disposition'] = (
+            'attachment; filename=transactions_anonymized.csv'
+        )
+        return resp
+
     @app.route('/export/inventory')
     @login_required
     def export_inventory():

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -62,6 +62,7 @@
             <ul class="submenu">
                 <li><a href="{{ url_for('log') }}">Verkäufe</a></li>
                 <li><a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a></li>
+                <li><a href="{{ url_for('export_transactions_anonymized') }}">CSV Verkäufe anonymisiert</a></li>
                 <li><a href="{{ url_for('file_logs') }}">Programmlogs</a></li>
             </ul>
         </li>


### PR DESCRIPTION
## Summary
- add new `/export/transactions_anonymized` endpoint that exports only drink names for each sale
- link anonymized CSV download in admin navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c75e5e0b48327894bb8cb1b7f61a6