### PR TITLE
Add Telegram notification bot with monthly reports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mfrc522
 rpi_ws281x
 adafruit-circuitpython-neopixel
 pyserial>=3.0
+requests>=2.0

--- a/src/models.py
+++ b/src/models.py
@@ -43,6 +43,26 @@ def set_admin_pin(pin: str, conn: Optional[sqlite3.Connection] = None) -> None:
     set_setting('admin_pin', pin, conn)
 
 
+def get_telegram_token(conn: Optional[sqlite3.Connection] = None) -> str:
+    """Return the Telegram bot token."""
+    return get_setting('telegram_token', conn) or ''
+
+
+def set_telegram_token(token: str, conn: Optional[sqlite3.Connection] = None) -> None:
+    """Store the Telegram bot token."""
+    set_setting('telegram_token', token, conn)
+
+
+def get_telegram_chat(conn: Optional[sqlite3.Connection] = None) -> str:
+    """Return the Telegram chat id for notifications."""
+    return get_setting('telegram_chat', conn) or ''
+
+
+def set_telegram_chat(chat_id: str, conn: Optional[sqlite3.Connection] = None) -> None:
+    """Store the Telegram chat id."""
+    set_setting('telegram_chat', chat_id, conn)
+
+
 
 @dataclass
 class User:

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1,0 +1,127 @@
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from . import models
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+LOG_DIR = BASE_DIR / 'logs'
+
+
+class TelegramNotifier:
+    """Simple Telegram bot for status reports."""
+
+    def __init__(self) -> None:
+        self.token: str = ''
+        self.chat_id: str = ''
+        self.offset: int = 0
+        self.last_month: str = ''
+        self.thread: Optional[threading.Thread] = None
+        self.running = False
+        self.reload_settings()
+
+    def reload_settings(self) -> None:
+        """Reload credentials from database."""
+        self.token = models.get_telegram_token()
+        self.chat_id = models.get_telegram_chat()
+
+    # --- Telegram API helpers -------------------------------------------------
+    def _api(self, method: str) -> str:
+        return f"https://api.telegram.org/bot{self.token}/{method}"
+
+    def _enabled(self) -> bool:
+        return bool(self.token and self.chat_id)
+
+    # --- Sending --------------------------------------------------------------
+    def send_message(self, text: str) -> None:
+        if not self._enabled():
+            return
+        try:
+            requests.post(self._api('sendMessage'), json={'chat_id': self.chat_id, 'text': text})
+        except Exception:
+            pass
+
+    def send_logfile(self) -> None:
+        if not self._enabled():
+            return
+        try:
+            logs = sorted(LOG_DIR.glob('log_*.txt'))
+            if not logs:
+                return
+            with open(logs[-1], 'rb') as f:
+                requests.post(
+                    self._api('sendDocument'),
+                    data={'chat_id': self.chat_id},
+                    files={'document': f},
+                )
+        except Exception:
+            pass
+
+    def build_status(self) -> str:
+        drinks = models.get_drinks_below_min()
+        stats, _ = models.get_monthly_stats(1)
+        lines: list[str] = []
+        if drinks:
+            lines.append('Nachzufüllende Getränke:')
+            for d in drinks:
+                lines.append(f"- {d.name}: {d.stock}/{d.min_stock}")
+        else:
+            lines.append('Alle Getränke ausreichend vorhanden.')
+        if stats:
+            s = stats[-1]
+            lines.append('')
+            lines.append('Monatsübersicht:')
+            lines.append(f"Aufladungen: {s['topup']/100:.2f} €")
+            lines.append(
+                f"Verkäufe Karte: {s['card_value']/100:.2f} € ({s['card_count']})"
+            )
+            lines.append(
+                f"Barverkäufe: {s['cash_value']/100:.2f} € ({s['cash_count']})"
+            )
+        return '\n'.join(lines)
+
+    def send_status(self) -> None:
+        text = self.build_status()
+        self.send_message(text)
+        self.send_logfile()
+
+    # --- Polling loop ---------------------------------------------------------
+    def _poll(self) -> None:
+        while self.running:
+            try:
+                if self._enabled():
+                    resp = requests.get(
+                        self._api('getUpdates'),
+                        params={'timeout': 60, 'offset': self.offset + 1},
+                        timeout=70,
+                    )
+                    data = resp.json()
+                    for upd in data.get('result', []):
+                        self.offset = max(self.offset, upd['update_id'])
+                        msg = upd.get('message', {}).get('text', '')
+                        if msg.strip() == '/status':
+                            self.send_status()
+                now = time.localtime()
+                month_tag = f"{now.tm_year:04d}-{now.tm_mon:02d}"
+                if month_tag != self.last_month and now.tm_mday == 1:
+                    self.last_month = month_tag
+                    self.send_status()
+            except Exception:
+                pass
+            time.sleep(5)
+
+    def start(self) -> None:
+        if self.thread and self.thread.is_alive():
+            return
+        self.running = True
+        self.thread = threading.Thread(target=self._poll, daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.running = False
+
+
+notifier = TelegramNotifier()

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -67,6 +67,7 @@
             </ul>
         </li>
         <li><a href="{{ url_for('settings') }}">Einstellungen</a></li>
+        <li><a href="{{ url_for('telegram') }}">Telegram</a></li>
         <li><a href="{{ url_for('change_password') }}">Passwort</a></li>
         <li><a href="{{ url_for('logout') }}">Logout</a></li>
     </ul>

--- a/src/web/templates/telegram.html
+++ b/src/web/templates/telegram.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Telegram Einstellungen</h1>
+<form method="post">
+    <label>Bot Token:<br>
+        <input type="text" name="token" value="{{ token }}">
+    </label><br>
+    <label>Chat ID:<br>
+        <input type="text" name="chat_id" value="{{ chat_id }}">
+    </label><br>
+    <button type="submit">Speichern</button>
+</form>
+{% if info %}<p class="info">{{ info }}</p>{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- store Telegram token and chat id in settings
- expose Telegram configuration page in web admin and start notifier
- implement threaded Telegram bot for monthly and on-demand status reports

## Testing
- `python -m py_compile src/telegram_bot.py src/web/admin_server.py src/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2fd1d9a7c83279929b3ac31459007