### PR TITLE
Fix sqlite column default

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -159,8 +159,9 @@ def upgrade_schema(conn: sqlite3.Connection) -> None:
     if "valid_until" not in cols:
         conn.execute("ALTER TABLE users ADD COLUMN valid_until DATE")
     if "created_at" not in cols:
+        conn.execute("ALTER TABLE users ADD COLUMN created_at DATETIME")
         conn.execute(
-            "ALTER TABLE users ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+            "UPDATE users SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL"
         )
 
     cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='admin_pin'")


### PR DESCRIPTION
## Summary
- avoid SQLite error when adding `created_at` column by using constant default and backfilling

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68b749e7fd348327af6defc3d342549e