### PR TITLE
Add PDF export with date range filtering

### DIFF
--- a/src/web/templates/event_cards.html
+++ b/src/web/templates/event_cards.html
@@ -13,7 +13,11 @@
 <td>{{ u['valid_until'] or '' }}</td>
 <td>{{ 'ja' if u['active'] else 'nein' }}</td>
 <td>{{ 'ja' if u['show_on_payment'] else 'nein' }}</td>
-<td><a href="{{ url_for('event_card_print', user_id=u['id']) }}" target="_blank">Druck</a></td>
+<td>
+    <form method="get" action="{{ url_for('event_card_print', user_id=u['id']) }}" target="_blank" style="display:inline">
+        <button type="submit">PDF</button>
+    </form>
+</td>
 <td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
 <td><a href="{{ url_for('event_card_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
 </tr>

--- a/src/web/templates/users.html
+++ b/src/web/templates/users.html
@@ -12,7 +12,6 @@
 <td>{{ u['rfid_uid'] }}</td>
 
 <td>{{ (u['balance']/100)|round(2) }} €</td>
-
 <td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
 <td><a href="{{ url_for('user_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
 </tr>


### PR DESCRIPTION
## Summary
- add PDF export for event cards with button in list
- ignore validity ranges for regular users and persist event card validity

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b74dd66be48327a7979a74521be19a