### PR TITLE
Fix PDF export and enforce event card validity

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -129,7 +129,10 @@ def get_event_payment_users() -> list[User]:
     try:
         with get_connection() as conn:
             cur = conn.execute(
-                'SELECT * FROM users WHERE is_event=1 AND show_on_payment=1 AND active=1 ORDER BY name'
+                'SELECT * FROM users WHERE is_event=1 AND show_on_payment=1 AND active=1 '
+                'AND (valid_from IS NULL OR valid_from <= DATE("now")) '
+                'AND (valid_until IS NULL OR valid_until >= DATE("now")) '
+                'ORDER BY name'
             )
             rows = cur.fetchall()
         return [User(**row) for row in rows]
@@ -142,7 +145,9 @@ def update_balance(user_id: int, diff: int) -> bool:
     try:
         with get_connection() as conn:
             cur = conn.execute(
-                'SELECT balance, is_event, active FROM users WHERE id = ?',
+                'SELECT balance, is_event, active FROM users WHERE id = ? '
+                'AND (valid_from IS NULL OR valid_from <= DATE("now")) '
+                'AND (valid_until IS NULL OR valid_until >= DATE("now"))',
                 (user_id,),
             )
             row = cur.fetchone()

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -557,17 +557,17 @@ def create_app() -> Flask:
             pdf.cell(40, 8, r['timestamp'][:10], 1)
             pdf.cell(70, 8, r['name'], 1)
             pdf.cell(20, 8, str(r['quantity']), 1, align='R')
-            pdf.cell(20, 8, f"{r['price']/100:.2f}", 1, align='R')
-            pdf.cell(20, 8, f"{r['quantity']*r['price']/100:.2f}", 1, align='R')
-            pdf.ln()
-        pdf.cell(150, 8, 'Gesamt', 1)
-        pdf.cell(20, 8, f"{total/100:.2f}", 1, align='R')
-        output = pdf.output(dest='S').encode('latin1')
-        return send_file(
-            io.BytesIO(output),
-            mimetype='application/pdf',
-            download_name=f'event_{user_id}.pdf',
-        )
+        pdf.cell(20, 8, f"{r['price']/100:.2f}", 1, align='R')
+        pdf.cell(20, 8, f"{r['quantity']*r['price']/100:.2f}", 1, align='R')
+        pdf.ln()
+    pdf.cell(150, 8, 'Gesamt', 1)
+    pdf.cell(20, 8, f"{total/100:.2f}", 1, align='R')
+    pdf_bytes = pdf.output()
+    return send_file(
+        io.BytesIO(pdf_bytes),
+        mimetype='application/pdf',
+        download_name=f'event_{user_id}.pdf',
+    )
 
     @app.route('/users/edit/<int:user_id>', methods=['GET', 'POST'])
     @login_required


### PR DESCRIPTION
## Summary
- generate PDF using fpdf2's bytes output to avoid Internal Server errors
- show and charge event cards only when they are valid for the current date

## Testing
- `python -m py_compile src/models.py src/web/admin_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7529086788327a27ccaf19f1b35a1