### PR TITLE
Add event card reset option and fix PDF generation

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -274,6 +274,21 @@ def add_topup(user_id: int, amount: int) -> None:
         print(f"Fehler beim Schreiben der Aufladung: {e}")
 
 
+def reset_event_card(user_id: int) -> None:
+    """Delete all transactions and validity dates for an event card."""
+    try:
+        with get_connection() as conn:
+            conn.execute('DELETE FROM transactions WHERE user_id=?', (user_id,))
+            conn.execute(
+                'UPDATE users SET balance=0, valid_from=NULL, valid_until=NULL '
+                'WHERE id=? AND is_event=1',
+                (user_id,),
+            )
+            conn.commit()
+    except sqlite3.Error as e:  # pragma: no cover - DB failure
+        print(f"Fehler beim Zurücksetzen der Veranstaltungskarte: {e}")
+
+
 def get_topup_log() -> list[sqlite3.Row]:
     try:
         with get_connection() as conn:

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -508,6 +508,12 @@ def create_app() -> Flask:
         conn.close()
         return redirect(url_for('event_cards'))
 
+    @app.route('/event_cards/reset/<int:user_id>', methods=['POST'])
+    @login_required
+    def event_card_reset(user_id: int):
+        models.reset_event_card(user_id)
+        return redirect(url_for('event_cards'))
+
     @app.route('/event_cards/print/<int:user_id>')
     @login_required
     def event_card_print(user_id: int):
@@ -557,17 +563,17 @@ def create_app() -> Flask:
             pdf.cell(40, 8, r['timestamp'][:10], 1)
             pdf.cell(70, 8, r['name'], 1)
             pdf.cell(20, 8, str(r['quantity']), 1, align='R')
-        pdf.cell(20, 8, f"{r['price']/100:.2f}", 1, align='R')
-        pdf.cell(20, 8, f"{r['quantity']*r['price']/100:.2f}", 1, align='R')
-        pdf.ln()
-    pdf.cell(150, 8, 'Gesamt', 1)
-    pdf.cell(20, 8, f"{total/100:.2f}", 1, align='R')
-    pdf_bytes = pdf.output()
-    return send_file(
-        io.BytesIO(pdf_bytes),
-        mimetype='application/pdf',
-        download_name=f'event_{user_id}.pdf',
-    )
+            pdf.cell(20, 8, f"{r['price']/100:.2f}", 1, align='R')
+            pdf.cell(20, 8, f"{r['quantity']*r['price']/100:.2f}", 1, align='R')
+            pdf.ln()
+        pdf.cell(150, 8, 'Gesamt', 1)
+        pdf.cell(20, 8, f"{total/100:.2f}", 1, align='R')
+        pdf_bytes = pdf.output()
+        return send_file(
+            io.BytesIO(pdf_bytes),
+            mimetype='application/pdf',
+            download_name=f'event_{user_id}.pdf',
+        )
 
     @app.route('/users/edit/<int:user_id>', methods=['GET', 'POST'])
     @login_required

--- a/src/web/templates/event_cards.html
+++ b/src/web/templates/event_cards.html
@@ -3,7 +3,7 @@
 <h1>Veranstaltungskarten</h1>
 {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
 <table>
-<tr><th>Firma</th><th>UID</th><th>Guthaben</th><th>Gültig von</th><th>Gültig bis</th><th>Aktiv</th><th>Zahlungsmethoden</th><th colspan="3">Aktion</th></tr>
+<tr><th>Firma</th><th>UID</th><th>Guthaben</th><th>Gültig von</th><th>Gültig bis</th><th>Aktiv</th><th>Zahlungsmethoden</th><th colspan="4">Aktion</th></tr>
 {% for u in users %}
 <tr>
 <td>{{ u['name'] }}</td>
@@ -19,6 +19,11 @@
     </form>
 </td>
 <td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
+<td>
+    <form method="post" action="{{ url_for('event_card_reset', user_id=u['id']) }}" style="display:inline" onsubmit="return confirm('Karte wirklich zurücksetzen?');">
+        <button type="submit">Zurücksetzen</button>
+    </form>
+</td>
 <td><a href="{{ url_for('event_card_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
## Summary
- allow administrators to reset event cards, wiping transactions and validity dates after confirmation
- correct event card PDF generation logic

## Testing
- `python -m py_compile src/web/admin_server.py src/models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b754d473c883278e0fd6f6eb5b9ab2