### PR TITLE
Clear validity dates when resetting event cards

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -275,14 +275,13 @@ def add_topup(user_id: int, amount: int) -> None:
 
 
 def reset_event_card(user_id: int) -> None:
-    """Reset an event card without removing transaction logs."""
+    """Clear the validity dates of an event card."""
     try:
         with get_connection() as conn:
-            today = datetime.now(LOCAL_TZ).strftime("%Y-%m-%d")
             conn.execute(
-                'UPDATE users SET balance=0, valid_from=?, valid_until=NULL '
+                'UPDATE users SET valid_from=NULL, valid_until=NULL '
                 'WHERE id=? AND is_event=1',
-                (today, user_id),
+                (user_id,),
             )
             conn.commit()
     except sqlite3.Error as e:  # pragma: no cover - DB failure


### PR DESCRIPTION
## Summary
- When an event card is reset, only its validity dates are cleared, balance remains untouched

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b75b20a14083279d9f689f6e0a6257