### PR TITLE
Redesign payment dialog and web admin with game toggle

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -167,6 +167,11 @@ def upgrade_schema(conn: sqlite3.Connection) -> None:
     cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='admin_pin'")
     if cur.fetchone()[0] == 0:
         conn.execute("INSERT INTO config(key, value) VALUES ('admin_pin', '1234')")
+
+    cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='tictactoe_enabled'")
+    if cur.fetchone()[0] == 0:
+        conn.execute("INSERT INTO config(key, value) VALUES ('tictactoe_enabled', '1')")
+
     conn.commit()
 
 
@@ -183,6 +188,9 @@ def init_db(conn: Optional[sqlite3.Connection] = None) -> None:
     upgrade_schema(conn)
     cursor.execute(
         "INSERT OR IGNORE INTO config (key, value) VALUES ('overdraft_limit', '0')"
+    )
+    cursor.execute(
+        "INSERT OR IGNORE INTO config (key, value) VALUES ('tictactoe_enabled', '1')"
     )
     conn.commit()
     add_sample_data(conn)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -24,81 +24,189 @@ class QuantityDialog(QtWidgets.QDialog):
         self.setWindowState(QtCore.Qt.WindowFullScreen)
         self.quantity = 1
         layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(40, 30, 40, 30)
+        layout.setSpacing(24)
 
         self.setObjectName("quantity_dialog")
+
+        base_style = """
+            #quantity_dialog {
+                background-color: #f4f6fb;
+            }
+            #quantity_dialog QLabel#title_label {
+                font-size: 32px;
+                font-weight: 700;
+                color: #0f172a;
+            }
+            #quantity_dialog QLabel#info_label {
+                font-size: 16px;
+                color: #475569;
+            }
+            #quantity_dialog QFrame#quantity_frame {
+                background-color: #ffffff;
+                border-radius: 24px;
+                padding: 24px;
+                border: 2px solid #e2e8f0;
+            }
+            #quantity_dialog QLabel#quantity_value {
+                font-size: 48px;
+                font-weight: 700;
+                color: #0f172a;
+            }
+            #quantity_dialog QPushButton[btnClass="quantity"] {
+                border-radius: 44px;
+                background-color: #1f2937;
+                color: #ffffff;
+                font-size: 42px;
+                min-width: 140px;
+                min-height: 140px;
+            }
+            #quantity_dialog QGroupBox#payment_group {
+                border: 2px solid #e2e8f0;
+                border-radius: 24px;
+                margin-top: 12px;
+                background-color: #ffffff;
+                font-size: 18px;
+                font-weight: 600;
+                color: #0f172a;
+                padding: 24px;
+            }
+            #quantity_dialog QPushButton[btnClass="payment"] {
+                border-radius: 20px;
+                background-color: #2563eb;
+                color: #ffffff;
+                font-size: 20px;
+                font-weight: 600;
+                min-height: 110px;
+                padding: 20px;
+                text-align: center;
+            }
+            #quantity_dialog QPushButton[btnClass="payment"][variant="cash"] {
+                background-color: #f97316;
+            }
+            #quantity_dialog QPushButton[btnClass="payment"][variant="event"] {
+                background-color: #0ea5e9;
+            }
+            #quantity_dialog QPushButton[btnClass="payment"]:hover {
+                background-color: #1d4ed8;
+            }
+            #quantity_dialog QPushButton[btnClass="action"] {
+                border-radius: 16px;
+                background-color: #e2e8f0;
+                color: #1f2937;
+                font-size: 18px;
+                font-weight: 600;
+                min-height: 70px;
+            }
+            #quantity_dialog QPushButton[btnClass="action"]:hover {
+                background-color: #cbd5f5;
+            }
+        """
+        self.setStyleSheet(base_style)
+
         pixmap = QtGui.QPixmap(drink.image) if drink.image else QtGui.QPixmap()
         if not pixmap.isNull():
-            layout.setContentsMargins(40, 40, 40, 40)
             image_path = Path(drink.image).as_posix()
-            # Keep the icon in the background so the layout of the payment buttons stays intact.
             style = (
                 f"#quantity_dialog{{"
                 f"background-image: url('{image_path}');"
                 "background-repeat: no-repeat;"
                 "background-position: top right;"
+                "background-origin: content;"
                 "}}"
             )
             existing_style = self.styleSheet()
             self.setStyleSheet(f"{existing_style}\n{style}" if existing_style else style)
 
         self.product_label = QtWidgets.QLabel(drink.name)
-        f = self.product_label.font()
-        f.setPointSize(24)
-        self.product_label.setFont(f)
+        self.product_label.setObjectName("title_label")
         self.product_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.product_label.setWordWrap(True)
         layout.addWidget(self.product_label)
 
-        qty_layout = QtWidgets.QHBoxLayout()
-        self.minus_btn = QtWidgets.QPushButton("-")
+        info_label = QtWidgets.QLabel(
+            "Bitte Menge wählen und danach eine Zahlungsart antippen."
+        )
+        info_label.setObjectName("info_label")
+        info_label.setAlignment(QtCore.Qt.AlignCenter)
+        info_label.setWordWrap(True)
+        layout.addWidget(info_label)
+
+        qty_frame = QtWidgets.QFrame()
+        qty_frame.setObjectName("quantity_frame")
+        qty_layout = QtWidgets.QHBoxLayout(qty_frame)
+        qty_layout.setContentsMargins(16, 16, 16, 16)
+        qty_layout.setSpacing(24)
+        self.minus_btn = QtWidgets.QPushButton("−")
         self.plus_btn = QtWidgets.QPushButton("+")
-        for b in (self.minus_btn, self.plus_btn):
-            b.setFixedSize(100, 100)
-            f = b.font()
-            f.setPointSize(32)
-            b.setFont(f)
+        for btn in (self.minus_btn, self.plus_btn):
+            btn.setProperty("btnClass", "quantity")
+            btn.setMinimumSize(140, 140)
         self.label = QtWidgets.QLabel(f"{self.quantity} Stück")
+        self.label.setObjectName("quantity_value")
         self.label.setAlignment(QtCore.Qt.AlignCenter)
-        font = self.label.font()
-        font.setPointSize(40)
-        font.setBold(True)
-        self.label.setFont(font)
-        self.label.setMinimumWidth(200)
+        self.label.setMinimumWidth(220)
         qty_layout.addWidget(self.minus_btn)
-        qty_layout.addWidget(self.label)
+        qty_layout.addWidget(self.label, stretch=1)
         qty_layout.addWidget(self.plus_btn)
-        layout.addLayout(qty_layout)
+        layout.addWidget(qty_frame)
 
         self.minus_btn.clicked.connect(self.dec)
         self.plus_btn.clicked.connect(self.inc)
 
-        grid = QtWidgets.QGridLayout()
-        self.cash_btn = QtWidgets.QPushButton("Bar")
+        payment_group = QtWidgets.QGroupBox("Zahlungsart wählen")
+        payment_group.setObjectName("payment_group")
+        payment_layout = QtWidgets.QGridLayout(payment_group)
+        payment_layout.setContentsMargins(12, 24, 12, 12)
+        payment_layout.setHorizontalSpacing(18)
+        payment_layout.setVerticalSpacing(18)
+
+        self.cash_btn = QtWidgets.QPushButton("Barzahlung")
+        self.cash_btn.setProperty("btnClass", "payment")
+        self.cash_btn.setProperty("variant", "cash")
+        self.cash_btn.setMinimumSize(220, 110)
         self.cash_btn.clicked.connect(self.cash)
-        self.chip_btn = QtWidgets.QPushButton("Chip")
+        self.chip_btn = QtWidgets.QPushButton("Chip / Karte")
+        self.chip_btn.setProperty("btnClass", "payment")
+        self.chip_btn.setProperty("variant", "chip")
+        self.chip_btn.setMinimumSize(220, 110)
         self.chip_btn.clicked.connect(self.accept)
-        buttons = [self.cash_btn, self.chip_btn]
+
+        payment_buttons: list[QtWidgets.QWidget] = [self.cash_btn, self.chip_btn]
 
         self._event_user_id: int | None = None
-        for user in models.get_event_payment_users():
-            btn = QtWidgets.QPushButton(user.name)
+        event_users = models.get_event_payment_users()
+        for user in event_users:
+            btn = QtWidgets.QPushButton(
+                f"{user.name}\n{user.balance / 100:.2f} €"
+            )
+            btn.setProperty("btnClass", "payment")
+            btn.setProperty("variant", "event")
+            btn.setToolTip("Veranstaltungskarte direkt belasten")
+            btn.setMinimumSize(220, 110)
             btn.clicked.connect(lambda _, uid=user.id: self._select_event_user(uid))
-            buttons.append(btn)
+            payment_buttons.append(btn)
 
-        for i, btn in enumerate(buttons):
-            r, c = divmod(i, 2)
-            f = btn.font()
-            f.setPointSize(18)
-            btn.setFont(f)
-            btn.setMinimumHeight(80)
-            grid.addWidget(btn, r, c)
+        columns = 3
+        for index, btn in enumerate(payment_buttons):
+            row, col = divmod(index, columns)
+            payment_layout.addWidget(btn, row, col)
+            payment_layout.setColumnStretch(col, 1)
 
-        layout.addLayout(grid)
+        if not event_users:
+            hint = QtWidgets.QLabel(
+                "Keine Veranstaltungskarten für die Schnellzahlung aktiviert."
+            )
+            hint.setObjectName("info_label")
+            hint.setAlignment(QtCore.Qt.AlignCenter)
+            hint.setWordWrap(True)
+            rows_used = (len(payment_buttons) + columns - 1) // columns
+            payment_layout.addWidget(hint, rows_used, 0, 1, columns)
+
+        layout.addWidget(payment_group)
 
         cancel_btn = QtWidgets.QPushButton("Abbrechen")
-        f = cancel_btn.font()
-        f.setPointSize(16)
-        cancel_btn.setFont(f)
-        cancel_btn.setMinimumHeight(60)
+        cancel_btn.setProperty("btnClass", "action")
         cancel_btn.clicked.connect(self.reject)
         layout.addWidget(cancel_btn)
 
@@ -552,6 +660,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.central.setObjectName("central_widget")
         self.setCentralWidget(self.central)
 
+        self._game_enabled: bool = True
+        self._setup_styles()
+
         data_dir = Path(__file__).resolve().parent.parent / 'data'
         self._default_bg = data_dir / 'background.png'
         self._thank_bg = data_dir / 'background_thanks.png'
@@ -569,8 +680,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.start_page = QtWidgets.QWidget()
         self.start_layout = QtWidgets.QGridLayout(self.start_page)
+        self.start_layout.setContentsMargins(30, 30, 30, 30)
+        self.start_layout.setHorizontalSpacing(24)
+        self.start_layout.setVerticalSpacing(24)
         self.current_page = 1
         self.page_count = 1
+        self._start_page_needs_refresh = False
         self._populate_start_page()
 
 
@@ -590,6 +705,8 @@ class MainWindow(QtWidgets.QMainWindow):
         game_font.setPointSize(20)
         self.game_button.setFont(game_font)
         self.game_button.setMinimumSize(260, 80)
+        self.game_button.setProperty("btnClass", "game")
+        self._apply_button_style(self.game_button)
         self.game_button.clicked.connect(self._start_tictactoe)
         self.game_button.hide()
         info_layout.addWidget(self.game_button, alignment=QtCore.Qt.AlignCenter)
@@ -618,7 +735,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stack.addWidget(self.event_card_page)
 
         self._pending_game: dict[str, Any] | None = None
-
+        self._sync_game_setting()
         self.show_start_page()
 
     def _apply_background(self, path: Path) -> None:
@@ -632,6 +749,78 @@ class MainWindow(QtWidgets.QMainWindow):
             )
         else:
             self.central.setStyleSheet("")
+
+    def _setup_styles(self) -> None:
+        self.setStyleSheet(
+            """
+            QPushButton[btnClass='tile'] {
+                border-radius: 18px;
+                background-color: #2a9d8f;
+                color: #ffffff;
+                font-size: 18px;
+                font-weight: 600;
+                padding: 18px 16px;
+            }
+            QPushButton[btnClass='tile'][accent='info'] {
+                background-color: #4f46e5;
+            }
+            QPushButton[btnClass='tile'][accent='secondary'] {
+                background-color: #028090;
+            }
+            QPushButton[btnClass='tile'][state='warning'] {
+                background-color: #f4a261;
+                color: #1f2937;
+            }
+            QPushButton[btnClass='tile'][state='error'] {
+                background-color: #e76f51;
+            }
+            QPushButton[btnClass='tile']:hover {
+                background-color: #23867b;
+            }
+            QPushButton[btnClass='nav'] {
+                border-radius: 12px;
+                background-color: rgba(15, 23, 42, 0.78);
+                color: #f8fafc;
+                font-size: 16px;
+                font-weight: 600;
+                padding: 10px 14px;
+            }
+            QPushButton[btnClass='nav'][accent='admin'] {
+                background-color: #ef4444;
+            }
+            QPushButton[btnClass='nav']:disabled {
+                background-color: rgba(148, 163, 184, 0.45);
+                color: #e2e8f0;
+            }
+            QPushButton[btnClass='game'] {
+                border-radius: 18px;
+                background-color: #9333ea;
+                color: #ffffff;
+                font-size: 20px;
+                font-weight: 700;
+                padding: 18px 28px;
+            }
+            QPushButton[btnClass='game']:hover {
+                background-color: #7c3aed;
+            }
+        """
+        )
+
+    @staticmethod
+    def _apply_button_style(button: QtWidgets.QPushButton) -> None:
+        style = button.style()
+        style.unpolish(button)
+        style.polish(button)
+        button.update()
+
+    def _sync_game_setting(self) -> None:
+        self._game_enabled = models.is_game_enabled()
+        if not self._game_enabled:
+            self._pending_game = None
+            self.game_button.hide()
+
+    def _game_message_duration(self) -> int:
+        return 25000 if self._game_enabled else 8000
 
     def _populate_start_page(self) -> None:
         layout = self.start_layout
@@ -649,7 +838,9 @@ class MainWindow(QtWidgets.QMainWindow):
         balance_btn = QtWidgets.QPushButton("Guthaben\nabfragen")
         balance_btn.setFont(font)
         balance_btn.setMinimumSize(220, 120)
-        balance_btn.setStyleSheet("background-color: #87cefa;")
+        balance_btn.setProperty("btnClass", "tile")
+        balance_btn.setProperty("accent", "info")
+        self._apply_button_style(balance_btn)
         balance_btn.clicked.connect(self._check_balance)
         layout.addWidget(balance_btn, 0, 0)
 
@@ -661,14 +852,14 @@ class MainWindow(QtWidgets.QMainWindow):
                 button.setIcon(QtGui.QIcon(drink.image))
                 button.setIconSize(QtCore.QSize(120, 120))
             button.setMinimumSize(220, 120)
-
-            style = ""
+            button.setProperty("btnClass", "tile")
             if drink.stock < 0:
-                style = "color: red;"
+                button.setProperty("state", "error")
             elif drink.stock < drink.min_stock:
-                style = "color: orange;"
-
-            button.setStyleSheet(style)
+                button.setProperty("state", "warning")
+            else:
+                button.setProperty("state", "normal")
+            self._apply_button_style(button)
             button.clicked.connect(lambda _, d=drink: self.on_drink_selected(d))
             r, c = divmod(idx + 1, 3)
             layout.addWidget(button, r, c)
@@ -681,6 +872,8 @@ class MainWindow(QtWidgets.QMainWindow):
             f.setPointSize(20)
             btn.setFont(f)
             btn.setFixedSize(nav_size)
+            btn.setProperty("btnClass", "nav")
+            self._apply_button_style(btn)
         self.prev_button.clicked.connect(self.prev_page)
         self.next_button.clicked.connect(self.next_page)
 
@@ -696,6 +889,9 @@ class MainWindow(QtWidgets.QMainWindow):
         f.setPointSize(12)
         self.admin_button.setFont(f)
         self.admin_button.setFixedSize(nav_size)
+        self.admin_button.setProperty("btnClass", "nav")
+        self.admin_button.setProperty("accent", "admin")
+        self._apply_button_style(self.admin_button)
         self.admin_button.clicked.connect(self._open_admin)
         layout.addWidget(self.admin_button, bottom, 2,
                          alignment=QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight)
@@ -709,6 +905,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._pending_game = None
         self.game_button.hide()
         self.game_button.setEnabled(True)
+        if self._start_page_needs_refresh:
+            self._rebuild_start_page()
+            self._start_page_needs_refresh = False
         self._apply_background(self._default_bg)
         self.stack.setCurrentWidget(self.start_page)
 
@@ -722,7 +921,8 @@ class MainWindow(QtWidgets.QMainWindow):
     ) -> None:
         self.info_label.setText(message)
         self._info_timer.stop()
-        if allow_game and game_context:
+        enable_game = allow_game and self._game_enabled and bool(game_context)
+        if enable_game:
             self._pending_game = game_context
             self.game_button.show()
             self.game_button.setEnabled(True)
@@ -905,10 +1105,6 @@ class MainWindow(QtWidgets.QMainWindow):
             if self._thank_bg.exists():
                 self._apply_background(self._thank_bg)
             thank_message = f"Danke {user.name}!\nKauf wird verbucht."
-            thank_message += (
-                "\n\nGewinne im Tic Tac Toe, dann ist dein Getränk gratis. "
-                "Bei einer Niederlage kostet es doppelt!"
-            )
             game_context = {
                 "user_id": user.id,
                 "drink_id": drink.id,
@@ -918,11 +1114,20 @@ class MainWindow(QtWidgets.QMainWindow):
                 "drink_name": drink.name,
                 "event_user": True,
             }
+            if self._game_enabled:
+                thank_message += (
+                    "\n\nGewinne im Tic Tac Toe, dann ist dein Getränk gratis. "
+                    "Bei einer Niederlage kostet es doppelt!"
+                    "\n\nTippe auf \"Tic Tac Toe spielen\" oder warte kurz,"
+                    " dann kehrst du automatisch zum Start zurück."
+                )
+            else:
+                thank_message += "\n\nDu kehrst gleich automatisch zum Startbildschirm zurück."
             self._show_info_message(
                 thank_message,
-                allow_game=True,
-                game_context=game_context,
-                auto_return_ms=20000,
+                allow_game=self._game_enabled,
+                game_context=game_context if self._game_enabled else None,
+                auto_return_ms=self._game_message_duration(),
             )
             return
         self._show_info_message("Bitte Karte auflegen…", auto_return_ms=None)
@@ -955,10 +1160,6 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         if new_user.balance < 0:
             msg += "\nBitte Guthaben aufladen!"
-        msg += (
-            "\n\nGewinne im Tic Tac Toe, dann ist dein Getränk gratis. "
-            "Bei einer Niederlage kostet es doppelt!"
-        )
         game_context = {
             "user_id": user.id,
             "drink_id": drink.id,
@@ -968,11 +1169,20 @@ class MainWindow(QtWidgets.QMainWindow):
             "drink_name": drink.name,
             "event_user": False,
         }
+        if self._game_enabled:
+            msg += (
+                "\n\nGewinne im Tic Tac Toe, dann ist dein Getränk gratis. "
+                "Bei einer Niederlage kostet es doppelt!"
+                "\n\nTippe auf \"Tic Tac Toe spielen\" oder warte kurz,"
+                " dann kehrst du automatisch zum Start zurück."
+            )
+        else:
+            msg += "\n\nDu kehrst gleich automatisch zum Startbildschirm zurück."
         self._show_info_message(
             msg,
-            allow_game=True,
-            game_context=game_context,
-            auto_return_ms=20000,
+            allow_game=self._game_enabled,
+            game_context=game_context if self._game_enabled else None,
+            auto_return_ms=self._game_message_duration(),
         )
         QtWidgets.QApplication.processEvents()
 
@@ -982,9 +1192,13 @@ class MainWindow(QtWidgets.QMainWindow):
             database.clear_exit_flag()
             QtWidgets.QApplication.quit()
             return
-        if self.stack.currentWidget() is self.start_page and database.refresh_needed(self.refresh_mtime):
+        if database.refresh_needed(self.refresh_mtime):
             self.refresh_mtime = database.REFRESH_FLAG.stat().st_mtime
-            self._rebuild_start_page()
+            self._start_page_needs_refresh = True
+            self._sync_game_setting()
+            if self.stack.currentWidget() is self.start_page:
+                self._rebuild_start_page()
+                self._start_page_needs_refresh = False
 
     def _rebuild_start_page(self) -> None:
         layout = self.start_layout

--- a/src/models.py
+++ b/src/models.py
@@ -43,6 +43,19 @@ def set_admin_pin(pin: str, conn: Optional[sqlite3.Connection] = None) -> None:
     set_setting('admin_pin', pin, conn)
 
 
+def is_game_enabled(conn: Optional[sqlite3.Connection] = None) -> bool:
+    """Return True if the Tic-Tac-Toe bonus game should be offered."""
+    val = get_setting('tictactoe_enabled', conn)
+    if val is None:
+        return True
+    return val != '0'
+
+
+def set_game_enabled(enabled: bool, conn: Optional[sqlite3.Connection] = None) -> None:
+    """Persist whether the Tic-Tac-Toe bonus game is available."""
+    set_setting('tictactoe_enabled', '1' if enabled else '0', conn)
+
+
 def get_telegram_token(conn: Optional[sqlite3.Connection] = None) -> str:
     """Return the Telegram bot token."""
     return get_setting('telegram_token', conn) or ''

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1,80 +1,326 @@
 <!doctype html>
+<!DOCTYPE html>
 <html lang="de">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Admin</title>
     <style>
-        body { margin:0; padding:0; font-family: Arial, sans-serif; background:#f0f0f0; }
-        nav { background:#003366; padding:0; }
-        nav ul { list-style:none; margin:0; padding:0; display:flex; flex-wrap:wrap; }
-        nav li { position:relative; }
-        nav a { color:#fff; text-decoration:none; padding:1em; display:block; font-size:1.1em; }
-        nav li:hover > a { background:#00224d; }
-        nav .submenu { display:none; position:absolute; left:0; top:100%; background:#003366; min-width:180px; z-index:5; }
-        nav .submenu li { width:100%; }
-        nav li:hover .submenu { display:block; }
-        .container { max-width:1000px; margin:1em auto; background:#fff; padding:1em; box-shadow:0 0 10px rgba(0,0,0,0.1); }
-        table { width:100%; border-collapse:collapse; margin-bottom:1em; }
-        th, td { border:1px solid #ccc; padding:0.5em; text-align:left; }
-        button { font-size:1em; padding:0.4em 1em; }
-        input[type=text], input[type=password], input[type=number], input[type=file] {
-            width:100%; box-sizing:border-box; margin-bottom:0.5em;
+        :root {
+            color-scheme: light;
         }
-        .error { color:red; }
-        .info { color:green; }
-        .negstock { background:#fdd; }
-        .pagination { text-align:center; margin:0.5em 0; }
-        .pagination a { margin:0 0.5em; text-decoration:none; }
-        .pagination span { margin:0 0.5em; }
-        @media(max-width:600px){
-            nav ul { flex-direction:column; }
-            nav .submenu { position:static; display:none; }
-            nav li:hover .submenu { display:block; }
-            table { font-size:0.9em; }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+            background: radial-gradient(circle at top left, #dbeafe 0%, #e0e7ff 40%, #f8fafc 100%);
+            min-height: 100vh;
+            color: #0f172a;
+        }
+        a { color: inherit; text-decoration: none; }
+        header.topbar {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background: rgba(15, 23, 42, 0.92);
+            backdrop-filter: blur(14px);
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+        }
+        .topbar-inner {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            padding: 0 1.5rem;
+            min-height: 68px;
+        }
+        .brand {
+            font-weight: 700;
+            font-size: 1.2rem;
+            color: #f8fafc;
+            letter-spacing: 0.03em;
+        }
+        nav { flex: 1; }
+        nav ul.menu {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+        nav ul.menu > li { position: relative; }
+        nav ul.menu > li > a {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.65rem 0.95rem;
+            border-radius: 999px;
+            color: #e2e8f0;
+            font-weight: 600;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+        nav ul.menu > li > a:hover {
+            background: rgba(148, 163, 184, 0.3);
+            color: #ffffff;
+        }
+        nav .submenu {
+            display: none;
+            position: absolute;
+            left: 0;
+            top: calc(100% + 0.5rem);
+            background: #ffffff;
+            min-width: 220px;
+            border-radius: 18px;
+            padding: 0.5rem;
+            box-shadow: 0 20px 50px rgba(15, 23, 42, 0.18);
+        }
+        nav .submenu li { width: 100%; }
+        nav .submenu a {
+            display: block;
+            padding: 0.6rem 1rem;
+            color: #0f172a;
+            border-radius: 12px;
+            font-weight: 600;
+        }
+        nav .submenu a:hover {
+            background: #eef2ff;
+            color: #1d4ed8;
+        }
+        nav ul.menu > li:hover .submenu { display: block; }
+        main.content {
+            max-width: 1200px;
+            margin: 2.5rem auto;
+            padding: 0 1.5rem 3rem;
+        }
+        .card {
+            background: #ffffff;
+            border-radius: 24px;
+            padding: 2rem;
+            box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+            margin-bottom: 2rem;
+        }
+        h1 {
+            font-size: 2rem;
+            margin: 0 0 1rem;
+            color: #0f172a;
+            letter-spacing: 0.02em;
+        }
+        h2 {
+            font-size: 1.4rem;
+            margin: 1.5rem 0 0.75rem;
+            color: #1f2937;
+        }
+        p { line-height: 1.6; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #ffffff;
+            border-radius: 20px;
+            overflow: hidden;
+            box-shadow: 0 20px 50px rgba(15, 23, 42, 0.1);
+            margin-bottom: 1.5rem;
+        }
+        th {
+            background: #0f172a;
+            color: #f8fafc;
+            font-weight: 600;
+            padding: 1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.75rem;
+        }
+        td {
+            padding: 1rem;
+            border-bottom: 1px solid #e2e8f0;
+        }
+        tr:nth-child(even) td { background: #f8fafc; }
+        .table-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+        button, .btn {
+            border: none;
+            border-radius: 12px;
+            background: #2563eb;
+            color: #ffffff;
+            padding: 0.75rem 1.6rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35rem;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+            text-decoration: none;
+        }
+        button:hover, .btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 20px 30px rgba(37, 99, 235, 0.2);
+        }
+        button.secondary, .btn.secondary {
+            background: #1f2937;
+            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+        }
+        button.danger, .btn.danger {
+            background: #ef4444;
+            box-shadow: 0 12px 24px rgba(239, 68, 68, 0.25);
+        }
+        input[type=text], input[type=password], input[type=number], input[type=file], input[type=date], select {
+            width: 100%;
+            padding: 0.65rem 1rem;
+            border-radius: 12px;
+            border: 1px solid #cbd5f5;
+            font-size: 1rem;
+            background: #f8fafc;
+            transition: border 0.2s ease, box-shadow 0.2s ease;
+        }
+        input:focus, select:focus {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+            background: #ffffff;
+        }
+        img.preview {
+            max-width: 220px;
+            border-radius: 16px;
+            margin-top: 0.75rem;
+            box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
+        }
+        label { font-weight: 600; color: #334155; display: block; margin-bottom: 0.35rem; }
+        .form-grid {
+            display: grid;
+            gap: 1.25rem;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        }
+        .form-section { display: grid; gap: 1.25rem; }
+        .actions { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1.5rem; }
+        .info { color: #059669; font-weight: 600; }
+        .error { color: #ef4444; font-weight: 600; }
+        .negstock { background: rgba(254, 202, 87, 0.3); }
+        .pagination {
+            display: flex;
+            gap: 0.75rem;
+            justify-content: center;
+            margin: 2rem 0;
+        }
+        .pagination a, .pagination span {
+            padding: 0.5rem 0.9rem;
+            border-radius: 999px;
+            font-weight: 600;
+            background: #e0e7ff;
+            color: #1f2937;
+        }
+        .pagination span { background: #c7d2fe; }
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.85rem;
+            font-weight: 600;
+        }
+        .status-pill.active { background: rgba(34, 197, 94, 0.18); color: #15803d; }
+        .status-pill.inactive { background: rgba(239, 68, 68, 0.18); color: #b91c1c; }
+        .status-pill.highlight { background: rgba(59, 130, 246, 0.18); color: #1d4ed8; }
+        .toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-weight: 600;
+            color: #1f2937;
+        }
+        .toggle input {
+            appearance: none;
+            width: 52px;
+            height: 28px;
+            border-radius: 999px;
+            background: #cbd5f5;
+            position: relative;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+        .toggle input::after {
+            content: "";
+            position: absolute;
+            top: 4px;
+            left: 4px;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: #ffffff;
+            transition: transform 0.2s ease;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
+        }
+        .toggle input:checked { background: #2563eb; }
+        .toggle input:checked::after { transform: translateX(24px); }
+        @media (max-width: 900px) {
+            .topbar-inner {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.75rem;
+                padding: 1rem 1.5rem;
+            }
+            nav ul.menu {
+                justify-content: flex-start;
+            }
+            nav .submenu {
+                position: static;
+                box-shadow: none;
+                padding: 0.25rem 0;
+                margin-top: 0.5rem;
+            }
+            nav ul.menu > li:hover .submenu,
+            nav ul.menu > li:focus-within .submenu { display: block; }
         }
     </style>
 </head>
 <body>
-<nav>
-    <ul class="menu">
-        <li><a href="{{ url_for('index') }}">Home</a></li>
-        <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
-        <li class="dropdown"><a href="#">Getränke</a>
-            <ul class="submenu">
-                <li><a href="{{ url_for('drinks') }}">Verwalten</a></li>
-                <li><a href="{{ url_for('export_inventory') }}">CSV Bestand</a></li>
-                <li><a href="{{ url_for('export_restocks') }}">CSV Auffüllungen</a></li>
+<header class="topbar">
+    <div class="topbar-inner">
+        <a class="brand" href="{{ url_for('index') }}">Getränkekasse Admin</a>
+        <nav>
+            <ul class="menu">
+                <li><a href="{{ url_for('index') }}">Home</a></li>
+                <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
+                <li class="dropdown"><a href="#">Getränke</a>
+                    <ul class="submenu">
+                        <li><a href="{{ url_for('drinks') }}">Verwalten</a></li>
+                        <li><a href="{{ url_for('export_inventory') }}">CSV Bestand</a></li>
+                        <li><a href="{{ url_for('export_restocks') }}">CSV Auffüllungen</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown"><a href="#">Benutzer</a>
+                    <ul class="submenu">
+                        <li><a href="{{ url_for('users') }}">Verwalten</a></li>
+                        <li><a href="{{ url_for('event_cards') }}">Veranstaltungskarten</a></li>
+                        <li><a href="{{ url_for('topup') }}">Aufladen</a></li>
+                        <li><a href="{{ url_for('topup_log') }}">Aufladungen</a></li>
+                        <li><a href="{{ url_for('export_topups') }}">CSV Aufladungen</a></li>
+                        <li><a href="{{ url_for('export_users') }}">CSV Benutzer</a></li>
+                        <li><a href="{{ url_for('import_users') }}">Import Benutzer</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown"><a href="#">Logs</a>
+                    <ul class="submenu">
+                        <li><a href="{{ url_for('log') }}">Verkäufe</a></li>
+                        <li><a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a></li>
+                        <li><a href="{{ url_for('export_transactions_anonymized') }}">CSV Verkäufe anonymisiert</a></li>
+                        <li><a href="{{ url_for('file_logs') }}">Programmlogs</a></li>
+                    </ul>
+                </li>
+                <li><a href="{{ url_for('settings') }}">Einstellungen</a></li>
+                <li><a href="{{ url_for('telegram') }}">Telegram</a></li>
+                <li><a href="{{ url_for('change_password') }}">Passwort</a></li>
+                <li><a href="{{ url_for('logout') }}">Logout</a></li>
             </ul>
-        </li>
-        <li class="dropdown"><a href="#">Benutzer</a>
-            <ul class="submenu">
-                  <li><a href="{{ url_for('users') }}">Verwalten</a></li>
-                  <li><a href="{{ url_for('event_cards') }}">Veranstaltungskarten</a></li>
-                  <li><a href="{{ url_for('topup') }}">Aufladen</a></li>
-                <li><a href="{{ url_for('topup_log') }}">Aufladungen</a></li>
-                <li><a href="{{ url_for('export_topups') }}">CSV Aufladungen</a></li>
-                <li><a href="{{ url_for('export_users') }}">CSV Benutzer</a></li>
-                <li><a href="{{ url_for('import_users') }}">Import Benutzer</a></li>
-            </ul>
-        </li>
-        <li class="dropdown"><a href="#">Logs</a>
-            <ul class="submenu">
-                <li><a href="{{ url_for('log') }}">Verkäufe</a></li>
-                <li><a href="{{ url_for('export_transactions') }}">CSV Verkäufe</a></li>
-                <li><a href="{{ url_for('export_transactions_anonymized') }}">CSV Verkäufe anonymisiert</a></li>
-                <li><a href="{{ url_for('file_logs') }}">Programmlogs</a></li>
-            </ul>
-        </li>
-        <li><a href="{{ url_for('settings') }}">Einstellungen</a></li>
-        <li><a href="{{ url_for('telegram') }}">Telegram</a></li>
-        <li><a href="{{ url_for('change_password') }}">Passwort</a></li>
-        <li><a href="{{ url_for('logout') }}">Logout</a></li>
-    </ul>
-
-</nav>
-<div class="container">
+        </nav>
+    </div>
+</header>
+<main class="content">
 {% block content %}{% endblock %}
-</div>
+</main>
 </body>
 </html>

--- a/src/web/templates/event_cards.html
+++ b/src/web/templates/event_cards.html
@@ -1,43 +1,85 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Veranstaltungskarten</h1>
-{% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
-<table>
-<tr><th>Firma</th><th>UID</th><th>Guthaben</th><th>Gültig von</th><th>Gültig bis</th><th>Aktiv</th><th>Zahlungsmethoden</th><th colspan="4">Aktion</th></tr>
-{% for u in users %}
-<tr>
-<td>{{ u['name'] }}</td>
-<td>{{ u['rfid_uid'] }}</td>
-<td>{{ (u['balance']/100)|round(2) }} €</td>
-<td>{{ u['valid_from'] or '' }}</td>
-<td>{{ u['valid_until'] or '' }}</td>
-<td>{{ 'ja' if u['active'] else 'nein' }}</td>
-<td>{{ 'ja' if u['show_on_payment'] else 'nein' }}</td>
-<td>
-    <form method="get" action="{{ url_for('event_card_print', user_id=u['id']) }}" target="_blank" style="display:inline">
-        <button type="submit">PDF</button>
+<div class="card">
+    <h1>Veranstaltungskarten</h1>
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+    <table>
+        <tr>
+            <th>Firma</th>
+            <th>UID</th>
+            <th>Guthaben</th>
+            <th>Gültigkeit</th>
+            <th>Status</th>
+            <th>Direktzahlung</th>
+            <th>Aktionen</th>
+        </tr>
+        {% for u in users %}
+        <tr>
+            <td>{{ u['name'] }}</td>
+            <td>{{ u['rfid_uid'] }}</td>
+            <td>{{ (u['balance']/100)|round(2) }} €</td>
+            <td>
+                {{ u['valid_from'] or '–' }}<br>
+                <small>bis {{ u['valid_until'] or 'unbegrenzt' }}</small>
+            </td>
+            <td>
+                <span class="status-pill {{ 'active' if u['active'] else 'inactive' }}">
+                    {{ 'Aktiv' if u['active'] else 'Inaktiv' }}
+                </span>
+            </td>
+            <td>
+                <span class="status-pill {{ 'highlight' if u['show_on_payment'] else 'inactive' }}">
+                    {{ 'Schnellwahl' if u['show_on_payment'] else 'Aus' }}
+                </span>
+            </td>
+            <td>
+                <div class="table-actions">
+                    <form method="get" action="{{ url_for('event_card_print', user_id=u['id']) }}" target="_blank">
+                        <button type="submit" class="secondary">PDF</button>
+                    </form>
+                    <a class="btn secondary" href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a>
+                    <form method="post" action="{{ url_for('event_card_reset', user_id=u['id']) }}" onsubmit="return confirm('Karte wirklich zurücksetzen?');">
+                        <button type="submit" class="secondary">Zurücksetzen</button>
+                    </form>
+                    <a class="btn danger" href="{{ url_for('event_card_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a>
+                </div>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</div>
+
+<div class="card">
+    <h2>Neue Karte anlegen</h2>
+    <form method="post" action="{{ url_for('event_card_add') }}" class="form-section">
+        <div class="form-grid">
+            <div>
+                <label for="name">Firmenname</label>
+                <input type="text" id="name" name="name" placeholder="Firmenname">
+            </div>
+            <div>
+                <label for="uid_new">RFID UID</label>
+                <input type="text" name="uid" id="uid_new" placeholder="UID">
+            </div>
+            <div>
+                <label for="valid_from">Gültig von</label>
+                <input type="date" name="valid_from" id="valid_from">
+            </div>
+            <div>
+                <label for="valid_until">Gültig bis</label>
+                <input type="date" name="valid_until" id="valid_until">
+            </div>
+        </div>
+        <label class="toggle">
+            <input type="checkbox" name="show_on_payment" value="1">
+            In der Zahlungsübersicht anzeigen
+        </label>
+        <div class="actions">
+            <button type="button" class="secondary" onclick="readUid('uid_new')">UID lesen</button>
+            <button type="submit">Karte hinzufügen</button>
+        </div>
     </form>
-</td>
-<td><a href="{{ url_for('user_edit', user_id=u['id']) }}">Bearbeiten</a></td>
-<td>
-    <form method="post" action="{{ url_for('event_card_reset', user_id=u['id']) }}" style="display:inline" onsubmit="return confirm('Karte wirklich zurücksetzen?');">
-        <button type="submit">Zurücksetzen</button>
-    </form>
-</td>
-<td><a href="{{ url_for('event_card_delete', user_id=u['id']) }}" onclick="return confirm('Benutzer wirklich löschen?');">Löschen</a></td>
-</tr>
-{% endfor %}
-</table>
-<h2>Neu</h2>
-<form method="post" action="{{ url_for('event_card_add') }}">
-    <input type="text" name="name" placeholder="Firmenname">
-    <input type="text" name="uid" id="uid_new" placeholder="UID">
-    <input type="date" name="valid_from" placeholder="Gültig von">
-    <input type="date" name="valid_until" placeholder="Gültig bis">
-    <label><input type="checkbox" name="show_on_payment" value="1"> Auf Zahlungsmethoden anzeigen</label>
-    <button type="button" onclick="readUid('uid_new')">UID lesen</button>
-    <button type="submit">Hinzufügen</button>
-</form>
+</div>
 <script>
 function readUid(targetId) {
     fetch('{{ url_for('read_uid') }}').then(r => r.json()).then(data => {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1,31 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Adminbereich</h1>
-<p>Willkommen!</p>
-
-<p>Guthaben aller Benutzer (ohne Veranstaltungskarten):
-   {{ (total_balance/100)|round(2) }} €</p>
-
-<form method="post" action="{{ url_for('refresh') }}">
-    <button type="submit">GUI aktualisieren</button>
-</form>
-
-<form method="post" action="{{ url_for('stop') }}" onsubmit="return confirm('Anwendung wirklich beenden?');">
-    <button type="submit">Beenden</button>
-</form>
+<div class="card">
+    <h1>Adminbereich</h1>
+    <p>Willkommen!</p>
+    <p>Guthaben aller Benutzer (ohne Veranstaltungskarten):
+        {{ (total_balance/100)|round(2) }} €</p>
+    <div class="actions">
+        <form method="post" action="{{ url_for('refresh') }}">
+            <button type="submit" class="secondary">GUI aktualisieren</button>
+        </form>
+        <form method="post" action="{{ url_for('stop') }}" onsubmit="return confirm('Anwendung wirklich beenden?');">
+            <button type="submit" class="danger">Beenden</button>
+        </form>
+    </div>
+</div>
 
 {% if to_buy %}
-<h2>Nachkaufen</h2>
-<table>
-<tr><th>Getränk</th><th>Bestand</th><th>Mindest</th></tr>
-{% for d in to_buy %}
-<tr class="{% if d.stock < d.min_stock %}negstock{% endif %}">
-<td>{{ d.name }}</td>
-<td>{{ d.stock }}</td>
-<td>{{ d.min_stock }}</td>
-</tr>
-{% endfor %}
-</table>
+<div class="card">
+    <h2>Nachkaufen</h2>
+    <table>
+        <tr><th>Getränk</th><th>Bestand</th><th>Mindest</th></tr>
+        {% for d in to_buy %}
+        <tr class="{% if d.stock < d.min_stock %}negstock{% endif %}">
+            <td>{{ d.name }}</td>
+            <td>{{ d.stock }}</td>
+            <td>{{ d.min_stock }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</div>
 {% endif %}
 
 {% endblock %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -1,31 +1,48 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Einstellungen</h1>
-<form method="post" enctype="multipart/form-data">
-    <label>Überziehungslimit in Euro:<br>
-        <input type="number" step="0.01" name="overdraft" value="{{ overdraft_limit/100 }}">
-    </label><br>
-    <label>Admin-PIN:<br>
-        <input type="text" name="admin_pin" value="{{ admin_pin }}">
-    </label><br>
-    <label>Webinterface QR-Code:<br>
-        <input type="file" name="qr_code" accept="image/png">
-    </label><br>
-    {% if qr_code_exists %}
-    <img src="{{ url_for('web_qr_png') }}" alt="QR-Code" style="max-width:200px;"><br>
-    {% endif %}
-    <label>Hintergrundbild:<br>
-        <input type="file" name="background" accept="image/png">
-    </label><br>
-    {% if background_exists %}
-    <img src="{{ url_for('background_png') }}" alt="Hintergrund" style="max-width:200px;"><br>
-    {% endif %}
-    <label>Hintergrundbild Dankesseite:<br>
-        <input type="file" name="thank_background" accept="image/png">
-    </label><br>
-    {% if thank_background_exists %}
-    <img src="{{ url_for('thank_background_png') }}" alt="Danke-Hintergrund" style="max-width:200px;"><br>
-    {% endif %}
-    <button type="submit">Speichern</button>
-</form>
+<div class="card">
+    <h1>Einstellungen</h1>
+    <form method="post" enctype="multipart/form-data" class="form-section">
+        <div class="form-grid">
+            <div>
+                <label for="overdraft">Überziehungslimit in Euro</label>
+                <input type="number" id="overdraft" step="0.01" name="overdraft" value="{{ overdraft_limit/100 }}">
+            </div>
+            <div>
+                <label for="admin_pin">Admin-PIN</label>
+                <input type="text" id="admin_pin" name="admin_pin" value="{{ admin_pin }}">
+            </div>
+        </div>
+        <label class="toggle">
+            <input type="checkbox" name="game_enabled" value="1" {% if game_enabled %}checked{% endif %}>
+            Tic-Tac-Toe Bonusspiel aktivieren
+        </label>
+        <div class="form-grid">
+            <div>
+                <label for="qr_code">Webinterface QR-Code</label>
+                <input type="file" id="qr_code" name="qr_code" accept="image/png">
+                {% if qr_code_exists %}
+                <img class="preview" src="{{ url_for('web_qr_png') }}" alt="QR-Code">
+                {% endif %}
+            </div>
+            <div>
+                <label for="background">Hintergrundbild</label>
+                <input type="file" id="background" name="background" accept="image/png">
+                {% if background_exists %}
+                <img class="preview" src="{{ url_for('background_png') }}" alt="Hintergrund">
+                {% endif %}
+            </div>
+            <div>
+                <label for="thank_background">Hintergrundbild Dankesseite</label>
+                <input type="file" id="thank_background" name="thank_background" accept="image/png">
+                {% if thank_background_exists %}
+                <img class="preview" src="{{ url_for('thank_background_png') }}" alt="Danke-Hintergrund">
+                {% endif %}
+            </div>
+        </div>
+        <div class="actions">
+            <button type="submit">Änderungen speichern</button>
+        </div>
+    </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a persisted Tic-Tac-Toe enable switch and refresh handling to the admin settings
- restyle the quantity/payment dialog and start screen, highlighting event cards as full payment options with clearer messaging
- refresh the web admin layout with a modern theme and reorganised settings and event card management views

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dd53871cb48327a301fa9dd3385b41