### PR TITLE
Ensure kiosk GUI runs full screen and refreshes faster

### DIFF
--- a/src/gui/admin_window.py
+++ b/src/gui/admin_window.py
@@ -12,7 +12,7 @@ class AdminWindow(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setWindowTitle("Admin")
-        self.resize(800, 480)
+        self.setWindowState(self.windowState() | QtCore.Qt.WindowFullScreen)
         layout = QtWidgets.QVBoxLayout(self)
         self.tabs = QtWidgets.QTabWidget()
         layout.addWidget(self.tabs)


### PR DESCRIPTION
## Summary
- open the main and admin windows directly in fullscreen mode for better readability on small displays
- enlarge the cancel button on the payment dialog and shorten info message durations to speed up the return to the start page
- enable the Tic Tac Toe option after cash payments with dedicated messaging so the game can be played regardless of the payment method

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dd601baf808327a9756f5cd6994ff1