### PR TITLE
Improve payment dialog layout and mobile dropdown navigation

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -38,7 +38,6 @@ class QuantityDialog(QtWidgets.QDialog):
         else:
             layout.setContentsMargins(48, 36, 48, 36)
             layout.setSpacing(24)
-        layout.setAlignment(QtCore.Qt.AlignTop)
 
         self.setObjectName("quantity_dialog")
 
@@ -309,7 +308,7 @@ class QuantityDialog(QtWidgets.QDialog):
 
         layout.addWidget(payment_frame, stretch=1)
 
-        layout.addSpacing(12 if self._compact_layout else 20)
+        layout.addStretch(1)
 
         cancel_btn = QtWidgets.QPushButton("Abbrechen")
         cancel_btn.setProperty("btnClass", "action")

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -89,7 +89,20 @@
             background: #eef2ff;
             color: #1d4ed8;
         }
-        nav ul.menu > li:hover .submenu { display: block; }
+        nav ul.menu > li:hover .submenu,
+        nav ul.menu > li.open .submenu { display: block; }
+        nav ul.menu > li.dropdown > a {
+            position: relative;
+        }
+        nav ul.menu > li.dropdown > a::after {
+            content: '\25BE';
+            font-size: 0.65rem;
+            margin-left: 0.35rem;
+            transition: transform 0.2s ease;
+        }
+        nav ul.menu > li.dropdown.open > a::after {
+            transform: rotate(180deg);
+        }
         main.content {
             max-width: 1200px;
             margin: 2.5rem auto;
@@ -273,7 +286,19 @@
                 margin-top: 0.5rem;
             }
             nav ul.menu > li:hover .submenu,
-            nav ul.menu > li:focus-within .submenu { display: block; }
+            nav ul.menu > li:focus-within .submenu,
+            nav ul.menu > li.open .submenu { display: block; }
+        }
+        @media (hover: none), (pointer: coarse) {
+            nav ul.menu > li.dropdown > a {
+                touch-action: manipulation;
+            }
+            nav .submenu {
+                position: static;
+                box-shadow: none;
+                padding: 0.25rem 0;
+                margin-top: 0.5rem;
+            }
         }
     </style>
 </head>
@@ -322,5 +347,38 @@
 <main class="content">
 {% block content %}{% endblock %}
 </main>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const dropdownItems = Array.from(document.querySelectorAll('nav ul.menu > li.dropdown'));
+        if (!dropdownItems.length) {
+            return;
+        }
+        const prefersTouch = window.matchMedia('(hover: none), (pointer: coarse)').matches;
+        if (!prefersTouch) {
+            return;
+        }
+
+        const closeAll = () => dropdownItems.forEach((item) => item.classList.remove('open'));
+
+        dropdownItems.forEach((item) => {
+            item.addEventListener('click', (event) => event.stopPropagation());
+            const link = item.querySelector('a');
+            if (!link) {
+                return;
+            }
+            link.addEventListener('click', (event) => {
+                const wasOpen = item.classList.contains('open');
+                closeAll();
+                if (!wasOpen) {
+                    item.classList.add('open');
+                }
+                event.preventDefault();
+                event.stopPropagation();
+            });
+        });
+
+        document.addEventListener('click', closeAll);
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- let the payment dialog stretch to full screen height so the cancel button is fixed at the bottom edge
- add touch-friendly dropdown toggling so navigation works on phones

## Testing
- not run (PyQt5 dependency missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68de1042d05c83279dc7bfd63667cae2