### PR TITLE
Web-admin security hardening, session timeout & login lockout; UI style tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Das Admin-Passwort lässt sich im Web-Admin über den Punkt "Passwort" ändern.
 
 Diese Implementierung dient als Ausgangspunkt und kann nach Bedarf erweitert werden (z.B. weitere Admin-Funktionen, Export, Hardware-Anbindung des RFID-Lesers).
 
+## Umgesetzte Security-Updates
+
+- Web-Login hat jetzt eine einfache Fehlversuchssperre: Nach mehreren falschen Anmeldungen wird die Anmeldung für kurze Zeit blockiert.
+- Web-Sessions laufen nach Inaktivität automatisch ab.
+- Ist noch das Standard-Passwort aktiv, wird nach dem Login direkt auf die Passwort-Änderung umgeleitet, bis ein neues Passwort gesetzt ist.
+- Backups: Die Datenbank-Backups auf USB (ca. 10 Tage Historie) bleiben unverändert bestehen.
+
 ## Update von älteren Versionen
 
 Um die neuen Funktionen (z.B. Auflade- und Bestandslog) ohne Datenverlust zu nutzen,

--- a/src/admin_auth.py
+++ b/src/admin_auth.py
@@ -23,6 +23,10 @@ def verify_password(password: str) -> bool:
     return hashlib.sha256(password.encode()).hexdigest() == get_password_hash()
 
 
+def is_default_password() -> bool:
+    return get_password_hash() == _default_hash()
+
+
 def set_password(password: str) -> None:
     ADMIN_PW_FILE.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1166,6 +1166,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def _setup_styles(self) -> None:
         self.setStyleSheet(
             """
+            QWidget {
+                color: #e2e8f0;
+            }
             QPushButton[btnClass='tile'] {
                 border-radius: 20px;
                 background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
@@ -1197,6 +1200,12 @@ class MainWindow(QtWidgets.QMainWindow):
                 color: #7f1d1d;
             }
             QPushButton[btnClass='tile']:hover {
+                border: 2px solid rgba(255, 255, 255, 0.85);
+                padding: 17px 15px;
+            }
+            QPushButton[btnClass='tile']:pressed {
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
+                    stop:0 #0284c7, stop:1 #4f46e5);
             }
             QPushButton[btnClass='nav'] {
                 border-radius: 14px;
@@ -1215,6 +1224,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 background-color: rgba(148, 163, 184, 0.45);
                 color: #e2e8f0;
             }
+            QPushButton[btnClass='nav']:hover {
+                background-color: rgba(30, 41, 59, 0.95);
+                border: 1px solid rgba(191, 219, 254, 0.7);
+            }
             QPushButton[btnClass='game'] {
                 border-radius: 20px;
                 background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
@@ -1225,6 +1238,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 padding: 18px 28px;
             }
             QPushButton[btnClass='game']:hover {
+                border: 2px solid rgba(255, 255, 255, 0.9);
             }
         """
         )

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -4,6 +4,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Optional
 import sqlite3
+import time
 
 from .. import admin_auth
 
@@ -20,16 +21,56 @@ from ..telegram_bot import notifier
 
 def create_app() -> Flask:
     app = Flask(__name__)
-    app.secret_key = 'change-me'
+    app.secret_key = models.get_setting('flask_secret') or 'change-me'
+    app.config.update(
+        SESSION_COOKIE_HTTPONLY=True,
+        SESSION_COOKIE_SAMESITE='Lax',
+        SESSION_COOKIE_SECURE=False,
+        PERMANENT_SESSION_LIFETIME=1800,
+    )
     PER_PAGE = 25
+    SESSION_TIMEOUT_SECONDS = 30 * 60
+    MAX_LOGIN_ATTEMPTS = 5
+    LOGIN_WINDOW_SECONDS = 5 * 60
+    LOCKOUT_SECONDS = 10 * 60
+    _login_attempts: dict[str, list[float]] = {}
+    _lockout_until: dict[str, float] = {}
+
 
     def login_required(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if not session.get('user'):
                 return redirect(url_for('login'))
+            last_seen = session.get('last_seen', 0)
+            now = time.time()
+            if last_seen and now - float(last_seen) > SESSION_TIMEOUT_SECONDS:
+                session.clear()
+                return redirect(url_for('login'))
+            session['last_seen'] = now
+            if admin_auth.is_default_password() and request.endpoint != 'change_password':
+                return redirect(url_for('change_password'))
             return func(*args, **kwargs)
         return wrapper
+
+    @app.after_request
+    def add_security_headers(response):
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        response.headers['Permissions-Policy'] = 'camera=(), microphone=(), geolocation=()'
+        response.headers['Content-Security-Policy'] = (
+            "default-src 'self'; "
+            "img-src 'self' data:; "
+            "style-src 'self' 'unsafe-inline'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "font-src 'self' data:; "
+            "connect-src 'self'; "
+            "frame-ancestors 'self'; "
+            "base-uri 'self'; "
+            "form-action 'self'"
+        )
+        return response
 
 
     @app.route('/read_uid')
@@ -111,6 +152,7 @@ def create_app() -> Flask:
                 error = 'Passwörter stimmen nicht überein'
             else:
                 admin_auth.set_password(new_pw1)
+                session['force_pw_change'] = False
                 info = 'Passwort gespeichert'
         return render_template('change_password.html', error=error, info=info)
 
@@ -229,18 +271,43 @@ def create_app() -> Flask:
     @app.route('/login', methods=['GET', 'POST'])
     def login():
         error: Optional[str] = None
+        client_ip = request.remote_addr or 'unknown'
+        now = time.time()
+        lockout_until = _lockout_until.get(client_ip, 0)
+        if lockout_until > now:
+            remaining = int(lockout_until - now)
+            error = f'Zu viele Fehlversuche. Bitte in {remaining} Sekunden erneut versuchen.'
+            return render_template('login.html', error=error)
+
         if request.method == 'POST':
             user = request.form.get('username')
             pw = request.form.get('password')
             if user == 'admin' and admin_auth.verify_password(pw or ''):
+                _login_attempts.pop(client_ip, None)
+                _lockout_until.pop(client_ip, None)
                 session['user'] = user
+                session['last_seen'] = now
+                session['force_pw_change'] = admin_auth.is_default_password()
+                if session['force_pw_change']:
+                    return redirect(url_for('change_password'))
                 return redirect(url_for('index'))
-            error = 'Falsche Zugangsdaten'
+
+            attempts = [ts for ts in _login_attempts.get(client_ip, []) if now - ts <= LOGIN_WINDOW_SECONDS]
+            attempts.append(now)
+            _login_attempts[client_ip] = attempts
+            if len(attempts) >= MAX_LOGIN_ATTEMPTS:
+                _lockout_until[client_ip] = now + LOCKOUT_SECONDS
+                _login_attempts.pop(client_ip, None)
+                error = 'Zu viele Fehlversuche. Bitte später erneut versuchen.'
+            else:
+                remaining = MAX_LOGIN_ATTEMPTS - len(attempts)
+                error = f'Falsche Zugangsdaten. Verbleibende Versuche: {remaining}'
+
         return render_template('login.html', error=error)
 
     @app.route('/logout')
     def logout():
-        session.pop('user', None)
+        session.clear()
         return redirect(url_for('login'))
 
     @app.route('/drinks')


### PR DESCRIPTION
### Motivation

- Improve security of the web admin interface by adding session handling, brute-force protection and security headers. 
- Encourage changing the default admin password on first login and make sessions expire after inactivity. 
- Refresh GUI appearance with small style and interaction improvements.

### Description

- Use `models.get_setting('flask_secret')` for `app.secret_key` and configure session cookie options and `PERMANENT_SESSION_LIFETIME` in `create_app()`.
- Implement session inactivity timeout and redirect to `change_password` when the default password is still active using the new `admin_auth.is_default_password()` helper.
- Add simple login rate limiting per client IP with an attempts window and lockout period, and surface remaining-attempt feedback on failed logins.
- Add `@app.after_request` security headers including `Content-Security-Policy`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy` and `X-Content-Type-Options`.
- Replace `session.pop('user', None)` with `session.clear()` on logout and set/clear `session['last_seen']` and `session['force_pw_change']` as part of login/password flows.
- Expose `is_default_password()` in `src/admin_auth.py` and keep safe atomic write for `set_password()`.
- Add a short “Umgesetzte Security-Updates” note to `README.md` documenting the new protections and behavior.
- UI polish in `src/gui/main_window.py`: global widget text color, hover/pressed borders and adjustments for tile/game/nav buttons.

### Testing

- Ran the existing test suite with `pytest`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0057066088832781d8a20c0976a9d9)