### PR TITLE
Add dark theme styles for GUI QuantityDialog and web admin (responsive tweaks)

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -80,41 +80,41 @@ class QuantityDialog(QtWidgets.QDialog):
 
         base_style = f"""
             #quantity_dialog {{
-                background-color: #f4f6fb;
+                background-color: #0b1220;
             }}
             #quantity_dialog QLabel#title_label {{
                 font-size: {style['title_font']};
                 font-weight: 700;
-                color: #0f172a;
+                color: #f8fafc;
             }}
             #quantity_dialog QLabel#info_label {{
                 font-size: {style['info_font']};
-                color: #475569;
+                color: #cbd5e1;
             }}
             #quantity_dialog QFrame#quantity_content {{
                 background-color: transparent;
             }}
             #quantity_dialog QFrame#quantity_frame {{
-                background-color: #ffffff;
+                background-color: rgba(15, 23, 42, 0.94);
                 border-radius: 24px;
                 padding: {style['frame_padding']};
-                border: 2px solid #e2e8f0;
+                border: 2px solid #334155;
             }}
             #quantity_dialog QLabel#quantity_value {{
                 font-size: {style['quantity_font']};
                 font-weight: 700;
-                color: #0f172a;
+                color: #f8fafc;
             }}
             #quantity_dialog QLabel#payment_title {{
                 font-size: {style['payment_title_font']};
                 font-weight: 700;
-                color: #0f172a;
+                color: #e2e8f0;
             }}
             #quantity_dialog QFrame#payment_frame {{
-                background-color: #ffffff;
+                background-color: rgba(15, 23, 42, 0.94);
                 border-radius: 24px;
                 padding: {style['payment_container_padding']};
-                border: 2px solid #e2e8f0;
+                border: 2px solid #334155;
             }}
             #quantity_dialog QPushButton[btnClass="quantity"] {{
                 border-radius: {style['quantity_btn_radius']};
@@ -147,15 +147,15 @@ class QuantityDialog(QtWidgets.QDialog):
             }}
             #quantity_dialog QPushButton[btnClass="action"] {{
                 border-radius: 16px;
-                background-color: #e2e8f0;
-                color: #1f2937;
+                background-color: #334155;
+                color: #f8fafc;
                 font-size: {style['action_font']};
                 font-weight: 600;
                 min-height: {style['action_height']};
                 padding: {style['action_padding']};
             }}
             #quantity_dialog QPushButton[btnClass="action"]:hover {{
-                background-color: #cbd5f5;
+                background-color: #475569;
             }}
             #quantity_dialog QPushButton[btnClass="action"][variant="cancel"] {{
                 background-color: #ef4444;

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -7,22 +7,31 @@
     <title>Admin</title>
     <style>
         :root {
-            color-scheme: light;
+            color-scheme: dark;
+            --bg: #0b1220;
+            --bg-soft: #121a2b;
+            --surface: #182235;
+            --surface-alt: #1f2a40;
+            --text: #e5e7eb;
+            --text-muted: #cbd5e1;
+            --border: #334155;
+            --primary: #60a5fa;
+            --primary-strong: #3b82f6;
         }
         * { box-sizing: border-box; }
         body {
             margin: 0;
             font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-            background: radial-gradient(circle at top left, #dbeafe 0%, #e0e7ff 40%, #f8fafc 100%);
+            background: radial-gradient(circle at top left, #1e293b 0%, #0f172a 45%, #020617 100%);
             min-height: 100vh;
-            color: #0f172a;
+            color: var(--text);
         }
         a { color: inherit; text-decoration: none; }
         header.topbar {
             position: sticky;
             top: 0;
             z-index: 100;
-            background: rgba(15, 23, 42, 0.92);
+            background: rgba(2, 6, 23, 0.95);
             backdrop-filter: blur(14px);
             box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
         }
@@ -38,7 +47,7 @@
         .brand {
             font-weight: 700;
             font-size: 1.2rem;
-            color: #f8fafc;
+            color: #f1f5f9;
             letter-spacing: 0.03em;
         }
         nav { flex: 1; }
@@ -58,12 +67,12 @@
             gap: 0.35rem;
             padding: 0.65rem 0.95rem;
             border-radius: 999px;
-            color: #e2e8f0;
+            color: var(--text-muted);
             font-weight: 600;
             transition: background 0.2s ease, color 0.2s ease;
         }
         nav ul.menu > li > a:hover {
-            background: rgba(148, 163, 184, 0.3);
+            background: rgba(148, 163, 184, 0.18);
             color: #ffffff;
         }
         nav .submenu {
@@ -71,7 +80,7 @@
             position: absolute;
             left: 0;
             top: calc(100% + 0.5rem);
-            background: #ffffff;
+            background: var(--surface);
             min-width: 220px;
             border-radius: 18px;
             padding: 0.5rem;
@@ -81,13 +90,13 @@
         nav .submenu a {
             display: block;
             padding: 0.6rem 1rem;
-            color: #0f172a;
+            color: var(--text);
             border-radius: 12px;
             font-weight: 600;
         }
         nav .submenu a:hover {
-            background: #eef2ff;
-            color: #1d4ed8;
+            background: rgba(96, 165, 250, 0.14);
+            color: #93c5fd;
         }
         nav ul.menu > li:hover .submenu,
         nav ul.menu > li.open .submenu { display: block; }
@@ -109,36 +118,36 @@
             padding: 0 1.5rem 3rem;
         }
         .card {
-            background: #ffffff;
+            background: var(--surface);
             border-radius: 24px;
             padding: 2rem;
-            box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+            box-shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
             margin-bottom: 2rem;
         }
         h1 {
             font-size: 2rem;
             margin: 0 0 1rem;
-            color: #0f172a;
+            color: var(--text);
             letter-spacing: 0.02em;
         }
         h2 {
             font-size: 1.4rem;
             margin: 1.5rem 0 0.75rem;
-            color: #1f2937;
+            color: var(--text-muted);
         }
         p { line-height: 1.6; }
         table {
             width: 100%;
             border-collapse: collapse;
-            background: #ffffff;
+            background: var(--surface);
             border-radius: 20px;
             overflow: hidden;
-            box-shadow: 0 20px 50px rgba(15, 23, 42, 0.1);
+            box-shadow: 0 20px 50px rgba(2, 6, 23, 0.4);
             margin-bottom: 1.5rem;
         }
         th {
-            background: #0f172a;
-            color: #f8fafc;
+            background: #020617;
+            color: #f1f5f9;
             font-weight: 600;
             padding: 1rem;
             text-transform: uppercase;
@@ -147,14 +156,14 @@
         }
         td {
             padding: 1rem;
-            border-bottom: 1px solid #e2e8f0;
+            border-bottom: 1px solid var(--border);
         }
-        tr:nth-child(even) td { background: #f8fafc; }
+        tr:nth-child(even) td { background: var(--surface-alt); }
         .table-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
         button, .btn {
             border: none;
             border-radius: 12px;
-            background: #2563eb;
+            background: var(--primary-strong);
             color: #ffffff;
             padding: 0.75rem 1.6rem;
             font-size: 1rem;
@@ -165,7 +174,7 @@
             justify-content: center;
             gap: 0.35rem;
             transition: transform 0.15s ease, box-shadow 0.15s ease;
-            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
             text-decoration: none;
         }
         button:hover, .btn:hover {
@@ -173,7 +182,7 @@
             box-shadow: 0 20px 30px rgba(37, 99, 235, 0.2);
         }
         button.secondary, .btn.secondary {
-            background: #1f2937;
+            background: #334155;
             box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
         }
         button.danger, .btn.danger {
@@ -184,16 +193,16 @@
             width: 100%;
             padding: 0.65rem 1rem;
             border-radius: 12px;
-            border: 1px solid #cbd5f5;
+            border: 1px solid var(--border);
             font-size: 1rem;
-            background: #f8fafc;
+            background: #0f172a;
             transition: border 0.2s ease, box-shadow 0.2s ease;
         }
         input:focus, select:focus {
             outline: none;
             border-color: #2563eb;
             box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
-            background: #ffffff;
+            background: var(--surface);
         }
         img.preview {
             max-width: 220px;
@@ -201,7 +210,7 @@
             margin-top: 0.75rem;
             box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18);
         }
-        label { font-weight: 600; color: #334155; display: block; margin-bottom: 0.35rem; }
+        label { font-weight: 600; color: var(--text-muted); display: block; margin-bottom: 0.35rem; }
         .form-grid {
             display: grid;
             gap: 1.25rem;
@@ -222,10 +231,10 @@
             padding: 0.5rem 0.9rem;
             border-radius: 999px;
             font-weight: 600;
-            background: #e0e7ff;
-            color: #1f2937;
+            background: #334155;
+            color: #e2e8f0;
         }
-        .pagination span { background: #c7d2fe; }
+        .pagination span { background: #1d4ed8; color: #f8fafc; }
         .status-pill {
             display: inline-flex;
             align-items: center;
@@ -235,15 +244,15 @@
             font-size: 0.85rem;
             font-weight: 600;
         }
-        .status-pill.active { background: rgba(34, 197, 94, 0.18); color: #15803d; }
-        .status-pill.inactive { background: rgba(239, 68, 68, 0.18); color: #b91c1c; }
-        .status-pill.highlight { background: rgba(59, 130, 246, 0.18); color: #1d4ed8; }
+        .status-pill.active { background: rgba(34, 197, 94, 0.2); color: #86efac; }
+        .status-pill.inactive { background: rgba(239, 68, 68, 0.2); color: #fca5a5; }
+        .status-pill.highlight { background: rgba(59, 130, 246, 0.18); color: #93c5fd; }
         .toggle {
             display: inline-flex;
             align-items: center;
             gap: 0.75rem;
             font-weight: 600;
-            color: #1f2937;
+            color: var(--text-muted);
         }
         .toggle input {
             appearance: none;
@@ -263,11 +272,11 @@
             width: 20px;
             height: 20px;
             border-radius: 50%;
-            background: #ffffff;
+            background: var(--surface);
             transition: transform 0.2s ease;
             box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
         }
-        .toggle input:checked { background: #2563eb; }
+        .toggle input:checked { background: var(--primary-strong); }
         .toggle input:checked::after { transform: translateX(24px); }
         @media (max-width: 900px) {
             .topbar-inner {
@@ -288,6 +297,81 @@
             nav ul.menu > li:hover .submenu,
             nav ul.menu > li:focus-within .submenu,
             nav ul.menu > li.open .submenu { display: block; }
+        }
+        @media (max-width: 520px) {
+            body {
+                font-size: 15px;
+            }
+            .topbar-inner {
+                padding: 0.65rem 0.85rem;
+                gap: 0.5rem;
+                min-height: auto;
+            }
+            .brand {
+                font-size: 1rem;
+            }
+            nav {
+                width: 100%;
+            }
+            nav ul.menu {
+                width: 100%;
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 0.4rem;
+            }
+            nav ul.menu > li > a {
+                width: 100%;
+                justify-content: center;
+                padding: 0.55rem 0.6rem;
+                font-size: 0.92rem;
+            }
+            nav .submenu {
+                margin-top: 0.35rem;
+                border: 1px solid var(--border);
+                border-radius: 12px;
+            }
+            main.content {
+                margin: 1rem auto;
+                padding: 0 0.65rem 1.25rem;
+            }
+            .card {
+                padding: 1rem;
+                border-radius: 14px;
+                margin-bottom: 1rem;
+            }
+            h1 {
+                font-size: 1.35rem;
+                margin-bottom: 0.65rem;
+            }
+            h2 {
+                font-size: 1.08rem;
+                margin-top: 1rem;
+            }
+            table {
+                display: block;
+                width: 100%;
+                overflow-x: auto;
+                white-space: nowrap;
+                border-radius: 14px;
+            }
+            th, td {
+                padding: 0.7rem;
+                font-size: 0.9rem;
+            }
+            button, .btn {
+                width: 100%;
+                padding: 0.8rem 1rem;
+            }
+            .actions {
+                gap: 0.5rem;
+            }
+            .pagination {
+                gap: 0.4rem;
+            }
+            .pagination a, .pagination span {
+                padding: 0.45rem 0.7rem;
+                font-size: 0.88rem;
+            }
         }
         @media (hover: none), (pointer: coarse) {
             nav ul.menu > li.dropdown > a {


### PR DESCRIPTION
### Motivation

- Provide a coherent dark theme across the desktop GUI and web admin UI to improve visual consistency and low-light usability.
- Improve layout behavior on small screens by adding responsive rules for narrow viewports.

### Description

- Updated the `QuantityDialog` stylesheet in `src/gui/main_window.py` to use darker background colors, adjusted text and border colors, and tweaked button styles to match the dark theme.
- Converted the web admin base stylesheet in `src/web/templates/base.html` to dark mode by switching `color-scheme` to `dark`, adding CSS color variables, and replacing many hard-coded colors with the new variables.
- Adjusted colors and shadows for header, navigation, cards, tables, forms, buttons, toggles, and status pills to improve contrast and visual hierarchy in dark mode.
- Added a mobile-specific `@media (max-width: 520px)` block in `src/web/templates/base.html` to improve spacing, typography, and layout for small screens.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006f6de24c83278c781a9d9cfdf5d3)