### PR TITLE
Document `start.sh` usage and add USB backup script + cron setup in `install.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,74 @@ Das Admin-Passwort lässt sich im Web-Admin über den Punkt "Passwort" ändern.
 
 Diese Implementierung dient als Ausgangspunkt und kann nach Bedarf erweitert werden (z.B. weitere Admin-Funktionen, Export, Hardware-Anbindung des RFID-Lesers).
 
+
+## Start per `start.sh`
+
+Für den täglichen Betrieb auf dem Raspberry Pi ist `start.sh` der empfohlene Einstiegspunkt.
+Das Skript:
+
+- erstellt automatisch ein Logfile unter `logs/log_YYYY-MM-DD_HH-MM-SS.txt`,
+- startet den Web-Admin (`src.web.admin_server`) im Hintergrund,
+- startet anschließend die GUI im Vollbild (`src.app --fullscreen`),
+- beendet den Webserver automatisch, wenn die GUI geschlossen wird.
+
+Starten:
+
+```bash
+./start.sh
+```
+
+> Hinweis: Das Skript bricht bewusst ab, wenn keine grafische Oberfläche (`DISPLAY`) verfügbar ist.
+
+### Autostart (Raspberry Pi Desktop / LXDE)
+
+Damit die Kasse nach dem Booten automatisch startet, kann `start.sh` in den LXDE-Autostart eingetragen werden:
+
+1. Datei öffnen oder anlegen:
+   ```bash
+   nano ~/.config/lxsession/LXDE-pi/autostart
+   ```
+2. Diese Zeile ergänzen:
+   ```text
+   @/bin/bash /home/pi/getraenkekasse/start.sh
+   ```
+3. Pfad bei Bedarf an deinen Installationsordner anpassen und Raspberry Pi neu starten.
+
+Alternativ kann ein `systemd`-Service verwendet werden; wichtig ist in jedem Fall, dass `start.sh` in einer Desktop-Session mit gesetzter `DISPLAY`-Variable läuft.
+
+## Integrierte Backup-Funktion & Cron
+
+Das Projekt enthält bereits eine integrierte Datenbank-Backup-Funktion:
+
+- `update.sh` erstellt vor einem Update automatisch ein Backup der Datei `data/getraenkekasse.db`.
+- Die Backups werden als `data/getraenkekasse.db.bak.<timestamp>` gespeichert.
+- Es werden automatisch nur die 10 neuesten Backups aufbewahrt (ältere werden gelöscht).
+
+Manuelle Wiederherstellung eines Backups:
+
+```bash
+./restore_backup.sh data/getraenkekasse.db.bak.<timestamp>
+```
+
+
+### USB-Backup-Skript (wird bei Installation automatisch angelegt)
+
+Ab sofort legt `install.sh` automatisch das Skript `/usr/local/bin/backup_to_usb.sh` an und macht es ausführbar.
+Zusätzlich wird automatisch folgender Cronjob gesetzt:
+
+```cron
+0 3 * * * /usr/local/bin/backup_to_usb.sh
+```
+
+Damit wird das USB-Backup jeden Tag um **03:00 Uhr** ausgeführt.
+Das Skript sichert standardmäßig von:
+
+- Quelle: `/home/paul/Desktop/getraenkekasse/data`
+- Ziel: `/media/paul/backup`
+- Log: `/home/paul/backup.log`
+
+Wenn der USB-Stick nicht gemountet ist, wird ein Fehler ins Log geschrieben und der Lauf beendet.
+
 ## Update von älteren Versionen
 
 Um die neuen Funktionen (z.B. Auflade- und Bestandslog) ohne Datenverlust zu nutzen,

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
+cd "$(dirname "$0")"
 
-sudo apt install python3-pyqt5
+sudo apt install -y python3-pyqt5
 
 # create venv and install requirements
 if [ -d venv ]; then
@@ -17,4 +18,41 @@ pip install -r requirements.txt
 
 ./venv/bin/python -c "import src.database as d; d.init_db()"
 
+# Install USB backup script
+BACKUP_SCRIPT="/usr/local/bin/backup_to_usb.sh"
+sudo tee "$BACKUP_SCRIPT" > /dev/null <<'SCRIPT'
+#!/bin/bash
+
+# ==== EINSTELLUNGEN ====
+BACKUP_SOURCE="/home/paul/Desktop/getraenkekasse/data"
+BACKUP_DEST="/media/paul/backup"
+LOGFILE="/home/paul/backup.log"
+TIMESTAMP=$(date "+%Y-%m-%d_%H-%M")
+DEST="$BACKUP_DEST/backup_$TIMESTAMP"
+
+# ==== STICK GEMOUNTET? ====
+if [ ! -d "$BACKUP_DEST" ]; then
+    echo "$(date) - ❌ Fehler: USB-Stick $BACKUP_DEST nicht gefunden!" >> "$LOGFILE"
+    exit 1
+fi
+
+# ==== BACKUP START ====
+mkdir -p "$DEST"
+cp -r "$BACKUP_SOURCE"/* "$DEST"
+
+if [ $? -eq 0 ]; then
+    echo "$(date) - ✅ Backup erfolgreich nach $DEST" >> "$LOGFILE"
+else
+    echo "$(date) - ⚠️ Fehler beim Backup-Vorgang!" >> "$LOGFILE"
+    exit 1
+fi
+SCRIPT
+sudo chmod +x "$BACKUP_SCRIPT"
+
+# Install cron job if missing
+CRON_ENTRY='0 3 * * * /usr/local/bin/backup_to_usb.sh'
+( crontab -l 2>/dev/null | grep -Fv "$CRON_ENTRY"; echo "$CRON_ENTRY" ) | crontab -
+
 echo "Installation abgeschlossen"
+echo "Backup-Skript installiert: $BACKUP_SCRIPT"
+echo "Cronjob gesetzt: $CRON_ENTRY"


### PR DESCRIPTION
### Motivation

- Provide a recommended startup flow for daily Raspberry Pi operation and document autostart options. 
- Add an automated USB backup mechanism and ensure it's installed and scheduled during setup.

### Description

- Expanded `README.md` with a `Start per start.sh` section describing `start.sh` behavior, LXDE autostart instructions, and the integrated backup/restore workflow. 
- Updated `install.sh` to `cd` into the script directory and use `sudo apt install -y python3-pyqt5` to avoid interactive prompts. 
- `install.sh` now writes `/usr/local/bin/backup_to_usb.sh`, makes it executable with `chmod +x`, and installs a daily cron entry `0 3 * * * /usr/local/bin/backup_to_usb.sh`. 
- Kept the existing virtualenv creation and DB initialization steps (`python3 -m venv venv`, `pip install -r requirements.txt`, and `./venv/bin/python -c "import src.database as d; d.init_db()"`).

### Testing

- No automated tests are present or were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021d09b3b0832799f25c72e91a6b9a)