### PR TITLE
Improve UI messaging & RFID dialog; add reports/exports and booking tests

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1072,8 +1072,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.info_label.setAlignment(QtCore.Qt.AlignCenter)
         font = self.info_label.font()
         font.setPointSize(21 if self._compact_display else 24)
+        font.setBold(True)
         self.info_label.setFont(font)
         self.info_label.setWordWrap(True)
+        self.info_label.setStyleSheet(
+            "QLabel { background: rgba(255,255,255,0.92); color: #000; border-radius: 18px; padding: 20px; }"
+        )
         info_layout.addWidget(self.info_label, alignment=QtCore.Qt.AlignCenter)
         self.game_button = QtWidgets.QPushButton("Tic Tac Toe spielen")
         game_font = self.game_button.font()
@@ -1366,7 +1370,10 @@ class MainWindow(QtWidgets.QMainWindow):
         game_context: dict[str, Any] | None = None,
         auto_return_ms: int | None = 4000,
     ) -> None:
-        self.info_label.setText(message)
+        display_message = message
+        if "Bitte Karte auflegen" in message or "Bitte Zielkarte auflegen" in message or "Bitte Admin-Karte auflegen" in message:
+            display_message = f"⬆️  Karte am oberen Leser auflegen\n\n{message}\n\n⬆️  Karte hier halten"
+        self.info_label.setText(display_message)
         self._info_timer.stop()
         enable_game = allow_game and self._game_enabled and bool(game_context)
         if enable_game:
@@ -1380,6 +1387,39 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stack.setCurrentWidget(self.info_page)
         if auto_return_ms is not None:
             self._info_timer.start(auto_return_ms)
+
+    def _show_big_message(self, title: str, message: str) -> None:
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowTitle(title)
+        dlg.setWindowState(QtCore.Qt.WindowFullScreen)
+        layout = QtWidgets.QVBoxLayout(dlg)
+        layout.setContentsMargins(40, 40, 40, 40)
+        panel = QtWidgets.QFrame()
+        panel.setStyleSheet(
+            "QFrame { background: rgba(255,255,255,0.95); border-radius: 22px; }"
+        )
+        panel_layout = QtWidgets.QVBoxLayout(panel)
+        t = QtWidgets.QLabel(title)
+        t_font = t.font()
+        t_font.setPointSize(28 if self._compact_display else 36)
+        t_font.setBold(True)
+        t.setFont(t_font)
+        t.setAlignment(QtCore.Qt.AlignCenter)
+        text = QtWidgets.QLabel(message)
+        m_font = text.font()
+        m_font.setPointSize(22 if self._compact_display else 28)
+        m_font.setBold(True)
+        text.setFont(m_font)
+        text.setWordWrap(True)
+        text.setAlignment(QtCore.Qt.AlignCenter)
+        ok = QtWidgets.QPushButton("Bestätigen")
+        ok.setMinimumHeight(72 if self._compact_display else 92)
+        ok.clicked.connect(dlg.accept)
+        panel_layout.addWidget(t)
+        panel_layout.addWidget(text, 1)
+        panel_layout.addWidget(ok)
+        layout.addWidget(panel, 1)
+        dlg.exec_()
 
     def show_admin_menu(self) -> None:
         self.admin_menu.reload_web_qr()
@@ -1444,13 +1484,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self._show_info_message("Bitte Karte auflegen…", auto_return_ms=None)
         uid = rfid.read_uid(show_dialog=False)
         if not uid:
-            QtWidgets.QMessageBox.warning(self, "Fehler", "Karte konnte nicht gelesen werden")
+            self._show_big_message("Fehler", "Karte konnte nicht gelesen werden.")
             self.show_start_page()
             return
         user = models.get_user_by_uid(uid)
         if not user:
             led.indicate_error()
-            QtWidgets.QMessageBox.warning(self, "Fehler", "Unbekannte Karte")
+            self._show_big_message("Fehler", "Unbekannte Karte.")
             self.show_start_page()
             return
         led.indicate_success()
@@ -1556,13 +1596,13 @@ class MainWindow(QtWidgets.QMainWindow):
             self._show_info_message("Bitte Karte auflegen…", auto_return_ms=None)
             uid = rfid.read_uid(show_dialog=False)
             if not uid:
-                QtWidgets.QMessageBox.warning(self, "Fehler", "Karte konnte nicht gelesen werden")
+                self._show_big_message("Fehler", "Karte konnte nicht gelesen werden.")
                 self.show_start_page()
                 return
             user = models.get_user_by_uid(uid)
             if not user:
                 led.indicate_error()
-                QtWidgets.QMessageBox.warning(self, "Fehler", "Unbekannte Karte")
+                self._show_big_message("Fehler", "Unbekannte Karte.")
                 self.show_start_page()
                 return
             total_price = 0
@@ -1624,7 +1664,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if dialog.event_user_id is not None:
             user = models.get_user(dialog.event_user_id)
             if not user:
-                QtWidgets.QMessageBox.warning(self, "Fehler", "Benutzer nicht gefunden")
+                self._show_big_message("Fehler", "Benutzer nicht gefunden.")
                 self.show_start_page()
                 return
             total_price = drink.price * quantity
@@ -1650,13 +1690,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self._show_info_message("Bitte Karte auflegen…", auto_return_ms=None)
         uid = rfid.read_uid(show_dialog=False)
         if not uid:
-            QtWidgets.QMessageBox.warning(self, "Fehler", "Karte konnte nicht gelesen werden")
+            self._show_big_message("Fehler", "Karte konnte nicht gelesen werden.")
             self.show_start_page()
             return
         user = models.get_user_by_uid(uid)
         if not user:
             led.indicate_error()
-            QtWidgets.QMessageBox.warning(self, "Fehler", "Unbekannte Karte")
+            self._show_big_message("Fehler", "Unbekannte Karte.")
             self.show_start_page()
             return
         total_price = drink.price * quantity
@@ -1739,7 +1779,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if pin_dialog.exec_() != QtWidgets.QDialog.Accepted or \
                     pin_dialog.pin != models.get_admin_pin():
                 led.indicate_error()
-                QtWidgets.QMessageBox.warning(self, "Fehler", "Kein Zugang")
+                self._show_big_message("Fehler", "Kein Zugang.")
                 self.show_start_page()
                 return
         led.indicate_success()

--- a/src/models.py
+++ b/src/models.py
@@ -512,3 +512,50 @@ def get_monthly_stats(months: int = 12) -> tuple[list[dict[str, int]], dict[str,
         return stats, totals
     finally:
         conn.close()
+
+
+def get_period_clause(period: str) -> str:
+    """Return SQLite strftime clause for day/week/month grouping."""
+    if period == "day":
+        return "%Y-%m-%d"
+    if period == "week":
+        return "%Y-W%W"
+    return "%Y-%m"
+
+
+def get_report_metrics(start: str | None = None, end: str | None = None) -> dict[str, list[sqlite3.Row]]:
+    """Return top articles, out-of-stock history and topup volumes."""
+    where = []
+    params: list[str] = []
+    if start:
+        where.append("timestamp >= ?")
+        params.append(start)
+    if end:
+        where.append("timestamp <= ?")
+        params.append(end)
+    tx_where = f"WHERE {' AND '.join(where)}" if where else ""
+    topup_where = tx_where
+
+    with get_connection() as conn:
+        top_articles = conn.execute(
+            "SELECT d.name AS drink_name, SUM(t.quantity) AS quantity, "
+            "SUM(t.quantity * d.price) AS revenue "
+            "FROM transactions t JOIN drinks d ON d.id = t.drink_id "
+            f"{tx_where} GROUP BY d.id ORDER BY quantity DESC, revenue DESC LIMIT 10",
+            params,
+        ).fetchall()
+        out_of_stock = conn.execute(
+            "SELECT d.name AS drink_name, r.timestamp, d.stock "
+            "FROM restocks r JOIN drinks d ON d.id = r.drink_id "
+            "WHERE d.stock <= 0 ORDER BY r.timestamp DESC LIMIT 100"
+        ).fetchall()
+        topup_volume = conn.execute(
+            "SELECT SUM(amount) AS total_amount, COUNT(*) AS total_count FROM topups "
+            f"{topup_where}",
+            params,
+        ).fetchall()
+    return {
+        "top_articles": top_articles,
+        "out_of_stock": out_of_stock,
+        "topup_volume": topup_volume,
+    }

--- a/src/rfid.py
+++ b/src/rfid.py
@@ -46,11 +46,18 @@ def read_uid(timeout: int = 10, show_dialog: bool = True) -> Optional[str]:
         msg_box.setWindowTitle("RFID")
         msg_box.setText("Bitte Karte auflegen…")
         font = msg_box.font()
-        font.setPointSize(20)
+        font.setPointSize(28)
+        font.setBold(True)
         msg_box.setFont(font)
         msg_box.setStandardButtons(QtWidgets.QMessageBox.NoButton)
         msg_box.setWindowModality(QtCore.Qt.ApplicationModal)
-        msg_box.setWindowFlags(msg_box.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
+        msg_box.setWindowFlags(
+            msg_box.windowFlags() | QtCore.Qt.WindowStaysOnTopHint | QtCore.Qt.FramelessWindowHint
+        )
+        msg_box.setStyleSheet(
+            "QMessageBox { background: white; } QLabel { color: black; font-weight: 700; }"
+        )
+        msg_box.showFullScreen()
         msg_box.show()
 
     start_time = time.time()

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -18,6 +18,14 @@ from .. import database, models
 from ..telegram_bot import notifier
 
 
+def _date_filter_clause(period: str) -> str:
+    if period == "day":
+        return "date('now', '-1 day')"
+    if period == "week":
+        return "date('now', '-7 day')"
+    return "date('now', '-1 month')"
+
+
 def create_app() -> Flask:
     app = Flask(__name__)
     app.secret_key = 'change-me'
@@ -71,6 +79,37 @@ def create_app() -> Flask:
     def dashboard():
         stats, totals = models.get_monthly_stats()
         return render_template('dashboard.html', stats=stats, totals=totals)
+
+    @app.route('/reports')
+    @login_required
+    def reports():
+        period = request.args.get('period', default='month', type=str)
+        if period not in {'day', 'week', 'month'}:
+            period = 'month'
+        date_clause = _date_filter_clause(period)
+        conn = database.get_connection()
+        top_articles = conn.execute(
+            "SELECT d.name AS drink_name, SUM(t.quantity) AS quantity, "
+            "SUM(t.quantity * d.price) AS revenue "
+            "FROM transactions t JOIN drinks d ON d.id = t.drink_id "
+            f"WHERE DATE(t.timestamp) >= {date_clause} "
+            "GROUP BY d.id ORDER BY quantity DESC, revenue DESC LIMIT 10"
+        ).fetchall()
+        topups = conn.execute(
+            "SELECT COALESCE(SUM(amount), 0) AS amount, COUNT(*) AS count "
+            f"FROM topups WHERE DATE(timestamp) >= {date_clause}"
+        ).fetchone()
+        stock = conn.execute(
+            "SELECT name, stock, min_stock, CASE WHEN min_stock > 0 THEN ROUND(stock * 1.0 / min_stock, 2) ELSE NULL END AS ratio "
+            "FROM drinks ORDER BY stock ASC, name"
+        ).fetchall()
+        conn.close()
+        forecast = []
+        for row in stock:
+            ratio = row["ratio"]
+            status = "kritisch" if row["stock"] <= 0 else ("niedrig" if row["stock"] < row["min_stock"] else "ok")
+            forecast.append({"name": row["name"], "stock": row["stock"], "min_stock": row["min_stock"], "ratio": ratio, "status": status})
+        return render_template("reports.html", period=period, top_articles=top_articles, topups=topups, forecast=forecast)
 
     @app.route('/dashboard/receipt')
     @login_required
@@ -744,25 +783,64 @@ def create_app() -> Flask:
     @app.route('/export/transactions_anonymized')
     @login_required
     def export_transactions_anonymized():
+        period = request.args.get('period', default='month', type=str)
+        date_clause = _date_filter_clause(period)
         conn = database.get_connection()
         cur = conn.execute(
             'SELECT t.timestamp, d.name as drink_name, t.quantity '
             'FROM transactions t '
             'JOIN drinks d ON d.id = t.drink_id '
+            f"WHERE DATE(t.timestamp) >= {date_clause} "
             'ORDER BY t.timestamp DESC'
         )
         rows = cur.fetchall()
         conn.close()
         out = io.StringIO()
         writer = csv.writer(out)
-        writer.writerow(['timestamp', 'drink', 'quantity'])
+        writer.writerow(['period', 'timestamp', 'drink', 'quantity'])
         for r in rows:
-            writer.writerow([r['timestamp'], r['drink_name'], r['quantity']])
+            writer.writerow([period, r['timestamp'], r['drink_name'], r['quantity']])
         resp = make_response(out.getvalue())
         resp.headers['Content-Type'] = 'text/csv'
         resp.headers['Content-Disposition'] = (
             'attachment; filename=transactions_anonymized.csv'
         )
+        return resp
+
+    @app.route('/export/report_metrics')
+    @login_required
+    def export_report_metrics():
+        period = request.args.get('period', default='month', type=str)
+        date_clause = _date_filter_clause(period)
+        conn = database.get_connection()
+        top_articles = conn.execute(
+            "SELECT d.name AS drink_name, SUM(t.quantity) AS quantity, "
+            "SUM(t.quantity * d.price) AS revenue "
+            "FROM transactions t JOIN drinks d ON d.id = t.drink_id "
+            f"WHERE DATE(t.timestamp) >= {date_clause} "
+            "GROUP BY d.id ORDER BY quantity DESC, revenue DESC LIMIT 10"
+        ).fetchall()
+        out_of_stock = conn.execute(
+            "SELECT d.name AS drink_name, COUNT(*) AS stockout_count "
+            "FROM drinks d WHERE d.stock <= 0 GROUP BY d.id ORDER BY stockout_count DESC"
+        ).fetchall()
+        topup_stats = conn.execute(
+            "SELECT COUNT(*) AS total_topups, COALESCE(SUM(amount), 0) AS topup_volume "
+            f"FROM topups WHERE DATE(timestamp) >= {date_clause}"
+        ).fetchone()
+        conn.close()
+
+        out = io.StringIO()
+        writer = csv.writer(out)
+        writer.writerow(['metric', 'name', 'value', 'value2', 'period'])
+        for row in top_articles:
+            writer.writerow(['top_article', row['drink_name'], row['quantity'], f"{row['revenue']/100:.2f}", period])
+        for row in out_of_stock:
+            writer.writerow(['out_of_stock_history', row['drink_name'], row['stockout_count'], '', period])
+        writer.writerow(['topup_volume', 'topups', topup_stats['total_topups'], f"{topup_stats['topup_volume']/100:.2f}", period])
+        resp = make_response(out.getvalue())
+        resp.headers['Content-Type'] = 'text/csv'
+        resp.headers['Content-Disposition'] = 'attachment; filename=report_metrics.csv'
         return resp
 
     @app.route('/export/inventory')

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -6,6 +6,7 @@
     <p>Guthaben aller Benutzer (ohne Veranstaltungskarten):
         {{ (total_balance/100)|round(2) }} €</p>
     <div class="actions">
+        <a class="btn" href="{{ url_for('reports') }}">Reports & Forecast</a>
         <form method="post" action="{{ url_for('refresh') }}">
             <button type="submit" class="secondary">GUI aktualisieren</button>
         </form>

--- a/src/web/templates/reports.html
+++ b/src/web/templates/reports.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h1>Reports / Lager & Forecast</h1>
+  <form method="get" class="actions">
+    <label for="period">Zeitraum</label>
+    <select name="period" id="period">
+      <option value="day" {% if period=='day' %}selected{% endif %}>Tag</option>
+      <option value="week" {% if period=='week' %}selected{% endif %}>Woche</option>
+      <option value="month" {% if period=='month' %}selected{% endif %}>Monat</option>
+    </select>
+    <button type="submit">Filtern</button>
+    <a class="btn secondary" href="{{ url_for('export_report_metrics', period=period) }}">CSV Kennzahlen</a>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Top-Artikel</h2>
+  <table><tr><th>Artikel</th><th>Menge</th><th>Umsatz (€)</th></tr>
+  {% for r in top_articles %}
+    <tr><td>{{ r.drink_name }}</td><td>{{ r.quantity }}</td><td>{{ '%.2f'|format((r.revenue or 0)/100) }}</td></tr>
+  {% endfor %}
+  </table>
+</div>
+
+<div class="card">
+  <h2>Aufladevolumen</h2>
+  <p>Anzahl Aufladungen: <strong>{{ topups.count }}</strong></p>
+  <p>Volumen: <strong>{{ '%.2f'|format((topups.amount or 0)/100) }} €</strong></p>
+</div>
+
+<div class="card">
+  <h2>Lagerstatus / Forecast</h2>
+  <table><tr><th>Artikel</th><th>Bestand</th><th>Min</th><th>Forecast</th></tr>
+  {% for f in forecast %}
+   <tr class="{% if f.status != 'ok' %}negstock{% endif %}"><td>{{ f.name }}</td><td>{{ f.stock }}</td><td>{{ f.min_stock }}</td><td>{{ f.status }}</td></tr>
+  {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/tests/test_booking_logic.py
+++ b/tests/test_booking_logic.py
@@ -1,0 +1,60 @@
+import sys
+import types
+
+qtwidgets = types.SimpleNamespace(QMessageBox=object, QApplication=object)
+qtcore = types.SimpleNamespace(Qt=types.SimpleNamespace())
+pyqt5 = types.SimpleNamespace(QtWidgets=qtwidgets, QtCore=qtcore)
+sys.modules.setdefault("PyQt5", pyqt5)
+sys.modules.setdefault("PyQt5.QtWidgets", qtwidgets)
+sys.modules.setdefault("PyQt5.QtCore", qtcore)
+
+from src import database, models
+
+
+def setup_db(tmp_path, monkeypatch):
+    db_file = tmp_path / 'test.db'
+    monkeypatch.setattr(database, 'DB_PATH', db_file)
+    conn = database.get_connection()
+    database.init_db(conn)
+    return conn
+
+
+def test_purchase_and_stock_update(tmp_path, monkeypatch):
+    conn = setup_db(tmp_path, monkeypatch)
+    user = conn.execute("SELECT id, balance FROM users WHERE name='Alice'").fetchone()
+    drink = conn.execute("SELECT id, price, stock FROM drinks WHERE name='Wasser'").fetchone()
+    assert models.update_balance(user['id'], -drink['price'])
+    assert models.update_drink_stock(drink['id'], -1)
+    models.add_transaction(user['id'], drink['id'], 1)
+    new_balance = conn.execute('SELECT balance FROM users WHERE id=?', (user['id'],)).fetchone()['balance']
+    new_stock = conn.execute('SELECT stock FROM drinks WHERE id=?', (drink['id'],)).fetchone()['stock']
+    assert new_balance == user['balance'] - drink['price']
+    assert new_stock == drink['stock'] - 1
+    conn.close()
+
+
+def test_topup_updates_balance_and_log(tmp_path, monkeypatch):
+    conn = setup_db(tmp_path, monkeypatch)
+    user = conn.execute("SELECT id, balance FROM users WHERE name='Bob'").fetchone()
+    assert models.update_balance(user['id'], 500)
+    models.add_topup(user['id'], 500)
+    new_balance = conn.execute('SELECT balance FROM users WHERE id=?', (user['id'],)).fetchone()['balance']
+    topup = conn.execute('SELECT amount FROM topups WHERE user_id=? ORDER BY id DESC LIMIT 1', (user['id'],)).fetchone()
+    assert new_balance == user['balance'] + 500
+    assert topup['amount'] == 500
+    conn.close()
+
+
+def test_storno_booking_restores_balance_and_stock(tmp_path, monkeypatch):
+    conn = setup_db(tmp_path, monkeypatch)
+    user = conn.execute("SELECT id, balance FROM users WHERE name='Alice'").fetchone()
+    drink = conn.execute("SELECT id, price, stock FROM drinks WHERE name='Cola'").fetchone()
+    models.update_balance(user['id'], -drink['price'])
+    models.update_drink_stock(drink['id'], -1)
+    models.update_balance(user['id'], drink['price'])
+    models.update_drink_stock(drink['id'], +1)
+    new_balance = conn.execute('SELECT balance FROM users WHERE id=?', (user['id'],)).fetchone()['balance']
+    new_stock = conn.execute('SELECT stock FROM drinks WHERE id=?', (drink['id'],)).fetchone()['stock']
+    assert new_balance == user['balance']
+    assert new_stock == drink['stock']
+    conn.close()


### PR DESCRIPTION
### Motivation
- Make on-screen messages clearer and more visible for users, especially for card interactions and errors.  
- Provide an enlarged, consistent full-screen dialog for critical errors and confirmations.  
- Add reporting and forecasting views and CSV exports for admin users.  
- Add basic unit tests for booking/transaction logic to catch regressions in DB operations.

### Description
- Update `MainWindow` UI: style `info_label` with rounded white panel, make card-prompt messages include arrows and explicit placement instructions, add a new `_show_big_message` full-screen dialog and replace several `QMessageBox.warning` calls to use it.  
- Improve RFID reader dialog in `src/rfid.py` by increasing font size, making text bold, using frameless full-screen presentation and applying a simple stylesheet.  
- Add reporting helpers to `src/models.py`: `get_period_clause` and `get_report_metrics` to fetch top articles, out-of-stock history and topup volumes.  
- Extend admin web UI in `src/web/admin_server.py`: add `_date_filter_clause`, a `/reports` route with a new `reports.html` template, update anonymized transaction export to include a `period` column, and add `/export/report_metrics` CSV export.  
- Add link to the new Reports page in `src/web/templates/index.html`.  
- Add unit tests in `tests/test_booking_logic.py` that stub minimal PyQt5 pieces, initialize a test DB and verify purchase/topup/storno flows against `models` functions.

### Testing
- Ran the new booking tests with `pytest tests/test_booking_logic.py` and they completed successfully.  
- Ran the test suite with `pytest -q` including the added tests and no failures were reported.  
- Verified the admin `/reports` page renders and CSV exports return CSV content in basic manual checks (UI/HTTP smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02207430b08327bf0f654db7f75cf7)