### PR TITLE
Add purchase recommendation/forecast (models, GUI, web, Telegram)

### DIFF
--- a/src/gui/admin_window.py
+++ b/src/gui/admin_window.py
@@ -47,14 +47,22 @@ class AdminWindow(QtWidgets.QWidget):
         self.tabs.addTab(widget, "Getränke")
         self.drink_list = QtWidgets.QListWidget()
         layout.addWidget(self.drink_list)
+        self.shopping_btn = QtWidgets.QPushButton("Einkaufen")
+        self.shopping_btn.clicked.connect(self.show_shopping_forecast)
+        layout.addWidget(self.shopping_btn)
         self.reload_drinks()
 
     def reload_drinks(self):
         self.drink_list.clear()
+        rec = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
+        rec_map = {r['id']: r for r in rec}
         conn = database.get_connection()
         cur = conn.execute('SELECT * FROM drinks ORDER BY name')
         for row in cur.fetchall():
-            self.drink_list.addItem(f"{row['name']} - {row['price']/100:.2f} €")
+            r = rec_map.get(row['id'])
+            buy = r['buy_qty'] if r else 0
+            trend = r['trend'] if r else '-'
+            self.drink_list.addItem(f"{row['name']} - {row['price']/100:.2f} € | Bestand {row['stock']} | Forecast {trend} | Kaufen {buy}")
         conn.close()
 
     def _setup_log_tab(self):
@@ -127,3 +135,14 @@ class AdminWindow(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(dlg)
         layout.addWidget(label)
         dlg.exec_()
+
+
+    def show_shopping_forecast(self):
+        recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
+        lines = ["Einkaufsliste (30 Tage):", ""]
+        for r in recs:
+            if r['buy_qty'] > 0:
+                lines.append(f"- {r['name']}: kaufen {r['buy_qty']} (Bestand {r['stock']}, verkauft {r['sold']})")
+        if len(lines) == 2:
+            lines.append("Aktuell nichts dringend nachkaufen.")
+        QtWidgets.QMessageBox.information(self, "Einkaufen", "\n".join(lines))

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1372,7 +1372,7 @@ class MainWindow(QtWidgets.QMainWindow):
     ) -> None:
         display_message = message
         if "Bitte Karte auflegen" in message or "Bitte Zielkarte auflegen" in message or "Bitte Admin-Karte auflegen" in message:
-            display_message = f"⬆️  Karte am oberen Leser auflegen\n\n{message}\n\n⬆️  Karte hier halten"
+            display_message = f"⬆️  Karte am oberen Leser auflegen\n\n{message}"
         self.info_label.setText(display_message)
         self._info_timer.stop()
         enable_game = allow_game and self._game_enabled and bool(game_context)

--- a/src/models.py
+++ b/src/models.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 import sqlite3
 from datetime import datetime
+import json
 from zoneinfo import ZoneInfo
 
 from .database import get_connection, get_setting, set_setting
@@ -419,6 +420,63 @@ def get_drinks_below_min(conn: Optional[sqlite3.Connection] = None) -> list[Drin
         if own and conn is not None:
             conn.close()
 
+
+
+
+def get_purchase_recommendations(days: int = 30, coverage_days: int = 21, replenish_cycle_days: int = 45) -> list[dict[str, int | float | str]]:
+    """Estimate buy quantities per drink from recent sales and reorder cycle."""
+    days = max(1, int(days))
+    coverage_days = max(1, int(coverage_days))
+    replenish_cycle_days = max(coverage_days, int(replenish_cycle_days))
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT d.id, d.name, d.stock, d.min_stock, COALESCE(SUM(t.quantity), 0) AS sold "
+            "FROM drinks d "
+            "LEFT JOIN transactions t ON t.drink_id = d.id AND DATE(t.timestamp) >= DATE('now', ?) "
+            "GROUP BY d.id ORDER BY d.name",
+            (f'-{days} day',),
+        ).fetchall()
+    recs = []
+    for row in rows:
+        sold = int(row['sold'] or 0)
+        stock = int(row['stock'] or 0)
+        min_stock = int(row['min_stock'] or 0)
+        daily_rate = sold / days
+        forecast_target = round(daily_rate * replenish_cycle_days)
+        target_stock = max(min_stock, forecast_target)
+        buy_qty = max(0, target_stock - stock)
+        if sold == 0 and stock < min_stock:
+            buy_qty = max(buy_qty, min_stock - stock)
+        trend = 'gut' if daily_rate >= 0.5 else ('ruhig' if sold == 0 else 'schwach')
+        recs.append({
+            'id': int(row['id']),
+            'name': row['name'],
+            'stock': stock,
+            'min_stock': min_stock,
+            'sold': sold,
+            'daily_rate': round(daily_rate, 2),
+            'target_stock': int(target_stock),
+            'buy_qty': int(buy_qty),
+            'trend': trend,
+            'is_low': stock < min_stock,
+        })
+    return recs
+
+
+def get_new_low_stock_recommendations(days: int = 30, coverage_days: int = 21, replenish_cycle_days: int = 45) -> list[dict[str, int | float | str]]:
+    """Return only newly low-stock drinks and persist notification state."""
+    recs = get_purchase_recommendations(days, coverage_days, replenish_cycle_days)
+    low_ids = {r['id'] for r in recs if r['is_low']}
+    raw = get_setting('low_stock_notified') or '[]'
+    try:
+        notified = set(int(x) for x in json.loads(raw))
+    except Exception:
+        notified = set()
+    new_low_ids = low_ids - notified
+    refreshed_notified = notified & low_ids
+    refreshed_notified |= new_low_ids
+    set_setting('low_stock_notified', json.dumps(sorted(refreshed_notified)))
+    return [r for r in recs if r['id'] in new_low_ids]
 
 
 def rfid_read_for_web() -> Optional[str]:

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -108,14 +108,18 @@ class TelegramNotifier:
 
     def build_status(self) -> str:
         drinks = models.get_drinks_below_min()
+        recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
         stats, _ = models.get_monthly_stats(1)
         lines: list[str] = []
         if drinks:
-            lines.append('Nachzufüllende Getränke:')
+            lines.append('Einkaufszettel (knapp):')
+            rec_map = {r['id']: r for r in recs}
             for d in drinks:
-                lines.append(f"- {d.name}: {d.stock}/{d.min_stock}")
+                r = rec_map.get(d.id)
+                qty = r['buy_qty'] if r else max(0, d.min_stock - d.stock)
+                lines.append(f"- {d.name}: kaufen {qty}")
         else:
-            lines.append('Alle Getränke ausreichend vorhanden.')
+            lines.append('Kein Einkauf dringend nötig.')
         if stats:
             s = stats[-1]
             lines.append('')
@@ -128,6 +132,17 @@ class TelegramNotifier:
                 f"Barverkäufe: {s['cash_value']/100:.2f} € ({s['cash_count']})"
             )
         return '\n'.join(lines)
+
+
+    def send_low_stock_alert_once(self) -> None:
+        """Send one-time alert when a drink newly drops below minimum stock."""
+        new_low = models.get_new_low_stock_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
+        if not new_low:
+            return
+        lines = ['Neuer Engpass erkannt:']
+        for r in new_low:
+            lines.append(f"- {r['name']}: kaufen {r['buy_qty']} (Min {r['min_stock']}, Bestand {r['stock']})")
+        self.send_message('\n'.join(lines))
 
     def send_status(self) -> None:
         text = self.build_status()
@@ -156,6 +171,8 @@ class TelegramNotifier:
                 now = time.localtime()
                 month_tag = f"{now.tm_year:04d}-{now.tm_mon:02d}"
                 last_day = calendar.monthrange(now.tm_year, now.tm_mon)[1]
+
+                self.send_low_stock_alert_once()
 
                 if now.tm_mday == last_day and now.tm_hour == 13 and now.tm_min == 0:
                     if month_tag != self.last_month:

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -71,7 +71,8 @@ def create_app() -> Flask:
         ).fetchone()
         total_balance = row['total'] if row else 0
         conn.close()
-        return render_template('index.html', to_buy=to_buy, total_balance=total_balance)
+        recommendations = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
+        return render_template('index.html', to_buy=to_buy, total_balance=total_balance, recommendations=recommendations[:5])
 
 
     @app.route('/dashboard')
@@ -104,13 +105,22 @@ def create_app() -> Flask:
             "FROM drinks ORDER BY stock ASC, name"
         ).fetchall()
         conn.close()
+        recommendations = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
         forecast = []
         for row in stock:
             ratio = row["ratio"]
             status = "kritisch" if row["stock"] <= 0 else ("niedrig" if row["stock"] < row["min_stock"] else "ok")
             forecast.append({"name": row["name"], "stock": row["stock"], "min_stock": row["min_stock"], "ratio": ratio, "status": status})
-        return render_template("reports.html", period=period, top_articles=top_articles, topups=topups, forecast=forecast)
+        return render_template("reports.html", period=period, top_articles=top_articles, topups=topups, forecast=forecast, recommendations=recommendations)
 
+
+
+    @app.route('/einkaufen')
+    @login_required
+    def einkaufen():
+        days = request.args.get('days', default=30, type=int)
+        recs = models.get_purchase_recommendations(days=days, coverage_days=21, replenish_cycle_days=max(45, days))
+        return render_template('shopping.html', days=days, recommendations=recs)
     @app.route('/dashboard/receipt')
     @login_required
     def dashboard_receipt():

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -310,6 +310,8 @@
             <ul class="menu">
                 <li><a href="{{ url_for('index') }}">Home</a></li>
                 <li><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
+                <li><a href="{{ url_for('reports') }}">Forecast</a></li>
+                <li><a href="{{ url_for('einkaufen') }}">Einkaufen</a></li>
                 <li class="dropdown"><a href="#">Getränke</a>
                     <ul class="submenu">
                         <li><a href="{{ url_for('drinks') }}">Verwalten</a></li>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -7,6 +7,7 @@
         {{ (total_balance/100)|round(2) }} €</p>
     <div class="actions">
         <a class="btn" href="{{ url_for('reports') }}">Reports & Forecast</a>
+        <a class="btn secondary" href="{{ url_for('einkaufen') }}">Einkaufen</a>
         <form method="post" action="{{ url_for('refresh') }}">
             <button type="submit" class="secondary">GUI aktualisieren</button>
         </form>
@@ -33,3 +34,4 @@
 {% endif %}
 
 {% endblock %}
+

--- a/src/web/templates/reports.html
+++ b/src/web/templates/reports.html
@@ -37,4 +37,13 @@
   {% endfor %}
   </table>
 </div>
+
+<div class="card">
+  <h2>Einkaufsempfehlung</h2>
+  <table><tr><th>Artikel</th><th>Verkauft</th><th>Trend</th><th>Kaufen</th></tr>
+  {% for r in recommendations %}
+    <tr><td>{{ r.name }}</td><td>{{ r.sold }}</td><td>{{ r.trend }}</td><td>{{ r.buy_qty }}</td></tr>
+  {% endfor %}
+  </table>
+</div>
 {% endblock %}

--- a/src/web/templates/shopping.html
+++ b/src/web/templates/shopping.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="card">
+  <h1>Einkaufsliste</h1>
+  <form method="get" class="actions">
+    <label for="days">Verkaufszeitraum (Tage)</label>
+    <input type="number" min="7" max="180" step="1" id="days" name="days" value="{{ days }}">
+    <button type="submit">Berechnen</button>
+  </form>
+  <table>
+    <tr><th>Getränk</th><th>Bestand</th><th>Verkauft</th><th>Trend</th><th>Zielbestand</th><th>Kaufen</th></tr>
+    {% for r in recommendations %}
+    <tr class="{% if r.buy_qty > 0 %}negstock{% endif %}"><td>{{ r.name }}</td><td>{{ r.stock }}</td><td>{{ r.sold }}</td><td>{{ r.trend }}</td><td>{{ r.target_stock }}</td><td><strong>{{ r.buy_qty }}</strong></td></tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Provide automated purchase recommendations based on recent sales to support restocking decisions.
- Surface forecasts and buy quantities in the admin GUI and web interface for faster action.
- Notify operators (via Telegram) when an item newly drops below its minimum stock.

### Description
- Implemented `get_purchase_recommendations` and `get_new_low_stock_recommendations` in `models.py` to compute per-drink forecasts, buy quantities and persist one-time low-stock notifications using `get_setting`/`set_setting`.
- Updated the desktop admin GUI in `src/gui/admin_window.py` to show recommendation info in the drinks list, added a new "Einkaufen" button and the `show_shopping_forecast` dialog displaying computed buy lists, and adjusted the drinks display formatting.
- Extended the web admin in `src/web/admin_server.py` to pass recommendations to templates, added a new `/einkaufen` route and `shopping.html` template, and updated `base.html`, `index.html` and `reports.html` to expose forecast and shopping links and tables.
- Integrated recommendations into `src/telegram_bot.py` by including buy quantities in `build_status` and adding `send_low_stock_alert_once` which is invoked in the bot polling loop to send one-time alerts for newly low-stock items.
- Small UI tweak in `src/gui/main_window.py` to simplify the card reader info message.

### Testing
- No automated tests were added or executed as part of this change.
- Existing automated test suite was not run by this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0224ba32c08327b063fcc297411f41)