### PR TITLE
Admin UI aufgeräumt: Einkauf sortiert, Doppelungen entfernt, Monatsreport ohne Anhänge

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -144,11 +144,12 @@ class TelegramNotifier:
             lines.append(f"- {r['name']}: kaufen {r['buy_qty']} (Min {r['min_stock']}, Bestand {r['stock']})")
         self.send_message('\n'.join(lines))
 
-    def send_status(self) -> None:
+    def send_status(self, include_files: bool = True) -> None:
         text = self.build_status()
         self.send_message(text)
-        self.send_logfile()
-        self.send_datafiles()
+        if include_files:
+            self.send_logfile()
+            self.send_datafiles()
 
     # --- Polling loop ---------------------------------------------------------
     def _poll(self) -> None:
@@ -177,7 +178,7 @@ class TelegramNotifier:
                 if now.tm_mday == last_day and now.tm_hour == 13 and now.tm_min == 0:
                     if month_tag != self.last_month:
                         self.last_month = month_tag
-                        self.send_status()
+                        self.send_status(include_files=False)
 
             except Exception:
                 pass

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -120,6 +120,7 @@ def create_app() -> Flask:
     def einkaufen():
         days = request.args.get('days', default=30, type=int)
         recs = models.get_purchase_recommendations(days=days, coverage_days=21, replenish_cycle_days=max(45, days))
+        recs = sorted(recs, key=lambda r: (-r['buy_qty'], -r['sold'], r['name'].lower()))
         return render_template('shopping.html', days=days, recommendations=recs)
     @app.route('/dashboard/receipt')
     @login_required

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -7,7 +7,6 @@
         {{ (total_balance/100)|round(2) }} €</p>
     <div class="actions">
         <a class="btn" href="{{ url_for('reports') }}">Reports & Forecast</a>
-        <a class="btn secondary" href="{{ url_for('einkaufen') }}">Einkaufen</a>
         <form method="post" action="{{ url_for('refresh') }}">
             <button type="submit" class="secondary">GUI aktualisieren</button>
         </form>
@@ -17,21 +16,6 @@
     </div>
 </div>
 
-{% if to_buy %}
-<div class="card">
-    <h2>Nachkaufen</h2>
-    <table>
-        <tr><th>Getränk</th><th>Bestand</th><th>Mindest</th></tr>
-        {% for d in to_buy %}
-        <tr class="{% if d.stock < d.min_stock %}negstock{% endif %}">
-            <td>{{ d.name }}</td>
-            <td>{{ d.stock }}</td>
-            <td>{{ d.min_stock }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-</div>
-{% endif %}
 
 {% endblock %}
 

--- a/src/web/templates/reports.html
+++ b/src/web/templates/reports.html
@@ -10,7 +10,6 @@
       <option value="month" {% if period=='month' %}selected{% endif %}>Monat</option>
     </select>
     <button type="submit">Filtern</button>
-    <a class="btn secondary" href="{{ url_for('export_report_metrics', period=period) }}">CSV Kennzahlen</a>
   </form>
 </div>
 
@@ -34,15 +33,6 @@
   <table><tr><th>Artikel</th><th>Bestand</th><th>Min</th><th>Forecast</th></tr>
   {% for f in forecast %}
    <tr class="{% if f.status != 'ok' %}negstock{% endif %}"><td>{{ f.name }}</td><td>{{ f.stock }}</td><td>{{ f.min_stock }}</td><td>{{ f.status }}</td></tr>
-  {% endfor %}
-  </table>
-</div>
-
-<div class="card">
-  <h2>Einkaufsempfehlung</h2>
-  <table><tr><th>Artikel</th><th>Verkauft</th><th>Trend</th><th>Kaufen</th></tr>
-  {% for r in recommendations %}
-    <tr><td>{{ r.name }}</td><td>{{ r.sold }}</td><td>{{ r.trend }}</td><td>{{ r.buy_qty }}</td></tr>
   {% endfor %}
   </table>
 </div>


### PR DESCRIPTION
### Motivation
- Die Admin-Oberflächen waren doppelt/überladen und der Einkaufseintrag nicht priorisiert, wodurch Nutzer verwirrt wurden.
- Der Monatsbericht per Telegram verschickte unnötige Dateien (CSV/Log), die nicht mehr automatisch versendet werden sollen.

### Description
- Sortiere die Einkaufsempfehlungen in der Webroute `/einkaufen` nach absteigender Kaufmenge, dann nach verkauftem Volumen und Name durch `sorted(..., key=lambda r: (-r['buy_qty'], -r['sold'], r['name'].lower()))` in `src/web/admin_server.py`.
- Entferne auf der Startseite den doppelten Link zur Einkaufsseite und das separate „Nachkaufen“-Widget in `src/web/templates/index.html` so dass jede Funktion nur einmal sichtbar ist.
- Entferne den CSV-Kennzahlen-Button und die doppelte Einkaufsempfehlungs-Karte aus `src/web/templates/reports.html`, damit die Reports-Seite nur Reporting/Inhalte anzeigt.
- Passe den Telegram-Notifier an: `send_status` akzeptiert jetzt `include_files: bool` und die automatische Monatsversendung nutzt `include_files=False`, sodass Log- und CSV-Dateien nicht mehr per Monatsreport gesendet werden (`src/telegram_bot.py`).

### Testing
- `python -m compileall src/web/admin_server.py src/telegram_bot.py` wurde ausgeführt und zeigte keine Kompilationsfehler.
- Die geänderten Dateien wurden lokal gestaged und ein Commit angelegt (`src/telegram_bot.py`, `src/web/admin_server.py`, `src/web/templates/index.html`, `src/web/templates/reports.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022890ada083278daccbe5fa1f6bf2)