### PR TITLE
Admin GUI: Einkaufs-Dialog mit Forecast-Tabelle

### DIFF
--- a/src/gui/admin_window.py
+++ b/src/gui/admin_window.py
@@ -47,7 +47,7 @@ class AdminWindow(QtWidgets.QWidget):
         self.tabs.addTab(widget, "Getränke")
         self.drink_list = QtWidgets.QListWidget()
         layout.addWidget(self.drink_list)
-        self.shopping_btn = QtWidgets.QPushButton("Einkaufen")
+        self.shopping_btn = QtWidgets.QPushButton("Einkaufen (Forecast)")
         self.shopping_btn.clicked.connect(self.show_shopping_forecast)
         layout.addWidget(self.shopping_btn)
         self.reload_drinks()
@@ -139,10 +139,47 @@ class AdminWindow(QtWidgets.QWidget):
 
     def show_shopping_forecast(self):
         recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
-        lines = ["Einkaufsliste (30 Tage):", ""]
-        for r in recs:
-            if r['buy_qty'] > 0:
-                lines.append(f"- {r['name']}: kaufen {r['buy_qty']} (Bestand {r['stock']}, verkauft {r['sold']})")
-        if len(lines) == 2:
-            lines.append("Aktuell nichts dringend nachkaufen.")
-        QtWidgets.QMessageBox.information(self, "Einkaufen", "\n".join(lines))
+        recs = sorted(recs, key=lambda r: (-r['buy_qty'], -r['forecast_qty'], r['name'].lower()))
+
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowTitle("Einkaufsliste mit Forecast")
+        dlg.setWindowState(QtCore.Qt.WindowFullScreen)
+        layout = QtWidgets.QVBoxLayout(dlg)
+
+        info = QtWidgets.QLabel("Zeitraum: Verkäufe der letzten 30 Tage, Forecast für 45 Tage")
+        layout.addWidget(info)
+
+        table = QtWidgets.QTableWidget(len(recs), 5)
+        table.setHorizontalHeaderLabels([
+            "Getränk", "Bestand", "Min. Bestand", "Forecast (45T)", "Empf. Mindest-Einkaufsmenge"
+        ])
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+
+        for row, r in enumerate(recs):
+            values = [
+                r['name'],
+                str(r['stock']),
+                str(r['min_stock']),
+                str(r['forecast_qty']),
+                str(r['buy_qty']),
+            ]
+            for col, value in enumerate(values):
+                item = QtWidgets.QTableWidgetItem(value)
+                if col > 0:
+                    item.setTextAlignment(QtCore.Qt.AlignCenter)
+                if r['buy_qty'] > 0:
+                    item.setBackground(QtGui.QColor('#ffe2e2'))
+                table.setItem(row, col, item)
+
+        header = table.horizontalHeader()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        for col in range(1, 5):
+            header.setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+
+        layout.addWidget(table)
+        close_btn = QtWidgets.QPushButton("Schließen")
+        close_btn.clicked.connect(dlg.accept)
+        layout.addWidget(close_btn)
+        dlg.exec_()

--- a/src/models.py
+++ b/src/models.py
@@ -442,8 +442,8 @@ def get_purchase_recommendations(days: int = 30, coverage_days: int = 21, replen
         stock = int(row['stock'] or 0)
         min_stock = int(row['min_stock'] or 0)
         daily_rate = sold / days
-        forecast_target = round(daily_rate * replenish_cycle_days)
-        target_stock = max(min_stock, forecast_target)
+        forecast_qty = round(daily_rate * replenish_cycle_days)
+        target_stock = max(min_stock, forecast_qty)
         buy_qty = max(0, target_stock - stock)
         if sold == 0 and stock < min_stock:
             buy_qty = max(buy_qty, min_stock - stock)
@@ -455,6 +455,7 @@ def get_purchase_recommendations(days: int = 30, coverage_days: int = 21, replen
             'min_stock': min_stock,
             'sold': sold,
             'daily_rate': round(daily_rate, 2),
+            'forecast_qty': int(forecast_qty),
             'target_stock': int(target_stock),
             'buy_qty': int(buy_qty),
             'trend': trend,


### PR DESCRIPTION
### Motivation
- Die vorhandene Einkaufsschaltfläche im Admin-Bereich lieferte nur eine einfache MessageBox und zeigte keinen Forecast für Bestellmengen an.
- Ziel ist eine übersichtliche Einkaufsliste/Tabelle im Admin-Menü mit Bestand, Mindestbestand, Forecast und empfohlener Mindest-Einkaufsmenge zur besseren Bestellplanung.

### Description
- Ändert die Beschriftung des Einkaufsbuttons in `src/gui/admin_window.py` zu `Einkaufen (Forecast)` und verknüpft ihn mit der neuen Tabellenansicht.
- Ersetzt die MessageBox durch einen fullscreen `QDialog` mit `QTableWidget`, das die Spalten `Getränk`, `Bestand`, `Min. Bestand`, `Forecast (45T)` und `Empf. Mindest-Einkaufsmenge` anzeigt.
- Sortiert Einträge nach Dringlichkeit (`buy_qty`, `forecast_qty`) und hebt Zeilen mit empfohlenem Einkauf farblich hervor.
- Ergänzt `get_purchase_recommendations` in `src/models.py` um das Feld `forecast_qty`, das den berechneten Forecast-Wert zurückliefert und in der GUI verwendet wird.

### Testing
- `python -m py_compile src/models.py src/gui/admin_window.py` wurde ausgeführt und hat erfolgreich kompiliert.
- Es wurden keine automatisierten Unit-Tests ausgeführt und keine Fehler während der statischen Kompilierung festgestellt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022d48f49883279898e38389c4d19b)