### PR TITLE
Add buyer PIN role and touchscreen 'Eingekauft' booking flow

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -167,6 +167,9 @@ def upgrade_schema(conn: sqlite3.Connection) -> None:
     cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='admin_pin'")
     if cur.fetchone()[0] == 0:
         conn.execute("INSERT INTO config(key, value) VALUES ('admin_pin', '1234')")
+    cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='buyer_pin'")
+    if cur.fetchone()[0] == 0:
+        conn.execute("INSERT INTO config(key, value) VALUES ('buyer_pin', '4321')")
 
     cur = conn.execute("SELECT COUNT(*) FROM config WHERE key='tictactoe_enabled'")
     if cur.fetchone()[0] == 0:
@@ -191,6 +194,9 @@ def init_db(conn: Optional[sqlite3.Connection] = None) -> None:
     )
     cursor.execute(
         "INSERT OR IGNORE INTO config (key, value) VALUES ('tictactoe_enabled', '1')"
+    )
+    cursor.execute(
+        "INSERT OR IGNORE INTO config (key, value) VALUES ('buyer_pin', '4321')"
     )
     conn.commit()
     add_sample_data(conn)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -808,6 +808,60 @@ class StockPage(QtWidgets.QWidget):
             self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(drink.min_stock)))
 
 
+class PurchasedPage(QtWidgets.QWidget):
+    """Page to book purchased bottles (restock) from touchscreen."""
+
+    def __init__(self, parent: "MainWindow"):
+        super().__init__(parent)
+        self._main = parent
+        layout = QtWidgets.QVBoxLayout(self)
+        self.table = QtWidgets.QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Getränk", "Bestand", "Gekauft"])
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
+        self.table.verticalHeader().setVisible(False)
+        layout.addWidget(self.table)
+        button_row = QtWidgets.QHBoxLayout()
+        self.book_btn = QtWidgets.QPushButton("Buchen")
+        self.back_btn = QtWidgets.QPushButton("Zurück")
+        button_row.addWidget(self.book_btn)
+        button_row.addWidget(self.back_btn)
+        layout.addLayout(button_row)
+        self.book_btn.clicked.connect(self.book)
+
+    def reload(self) -> None:
+        recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
+        recs = sorted(recs, key=lambda r: (-r['buy_qty'], -r['sold'], r['name'].lower()))
+        self.table.setRowCount(len(recs))
+        self._drink_ids: list[int] = []
+        for row, rec in enumerate(recs):
+            self._drink_ids.append(rec['id'])
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(rec['name']))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(str(rec['stock'])))
+            spin = QtWidgets.QSpinBox()
+            spin.setRange(0, 10000)
+            spin.setValue(0)
+            self.table.setCellWidget(row, 2, spin)
+
+    def book(self) -> None:
+        booked = 0
+        for row, drink_id in enumerate(self._drink_ids):
+            spin = self.table.cellWidget(row, 2)
+            qty = spin.value() if isinstance(spin, QtWidgets.QSpinBox) else 0
+            if qty > 0:
+                models.update_drink_stock(drink_id, qty)
+                models.log_restock(drink_id, qty)
+                booked += qty
+        if booked == 0:
+            QtWidgets.QMessageBox.information(self, "Eingekauft", "Keine Menge eingegeben.")
+            return
+        led.indicate_success()
+        QtWidgets.QMessageBox.information(self, "Eingekauft", "Einkauf wurde gebucht.")
+        self._main.show_admin_menu()
+
+
 class AdminMenu(QtWidgets.QWidget):
     """Main admin menu with navigation buttons."""
 
@@ -816,6 +870,7 @@ class AdminMenu(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout(self)
 
         self.stock_btn = QtWidgets.QPushButton("Einkaufen")
+        self.purchased_btn = QtWidgets.QPushButton("Eingekauft")
         self.topup_btn = QtWidgets.QPushButton("Konten aufladen")
         self.event_cards_btn = QtWidgets.QPushButton("Veranstaltungskarten")
         self.status_btn = QtWidgets.QPushButton("Status")
@@ -825,6 +880,7 @@ class AdminMenu(QtWidgets.QWidget):
 
         for btn in (
             self.stock_btn,
+            self.purchased_btn,
             self.topup_btn,
             self.event_cards_btn,
             self.status_btn,
@@ -841,6 +897,14 @@ class AdminMenu(QtWidgets.QWidget):
         self.reload_web_qr()
 
         layout.addStretch(1)
+
+    def set_role(self, role: str) -> None:
+        is_buyer = role == "buyer"
+        self.topup_btn.setVisible(not is_buyer)
+        self.event_cards_btn.setVisible(not is_buyer)
+        self.status_btn.setVisible(not is_buyer)
+        self.web_btn.setVisible(not is_buyer)
+        self.quit_btn.setVisible(not is_buyer)
 
     def reload_web_qr(self) -> None:
         self.web_btn.setIcon(QtGui.QIcon())
@@ -1097,6 +1161,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.admin_menu = AdminMenu(self)
         self.admin_menu.stock_btn.clicked.connect(self.show_shopping_forecast)
+        self.admin_menu.purchased_btn.clicked.connect(self.show_purchased_page)
         self.admin_menu.topup_btn.clicked.connect(self.show_topup_page)
         self.admin_menu.event_cards_btn.clicked.connect(self.show_event_cards_page)
         self.admin_menu.status_btn.clicked.connect(self.show_status)
@@ -1108,6 +1173,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stock_page = StockPage(self)
         self.stock_page.back_btn.clicked.connect(self.show_admin_menu)
         self.stack.addWidget(self.stock_page)
+        self.purchased_page = PurchasedPage(self)
+        self.purchased_page.back_btn.clicked.connect(self.show_admin_menu)
+        self.stack.addWidget(self.purchased_page)
 
         self.topup_page = TopupPage(self)
         self.topup_page.back_btn.clicked.connect(self.show_admin_menu)
@@ -1117,6 +1185,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.stack.addWidget(self.event_card_page)
 
         self._pending_game: dict[str, Any] | None = None
+        self._admin_role = "admin"
         self._sync_game_setting()
         self.show_start_page()
 
@@ -1423,11 +1492,16 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def show_admin_menu(self) -> None:
         self.admin_menu.reload_web_qr()
+        self.admin_menu.set_role(self._admin_role)
         self.stack.setCurrentWidget(self.admin_menu)
 
     def show_stock_page(self) -> None:
         self.stock_page.reload()
         self.stack.setCurrentWidget(self.stock_page)
+
+    def show_purchased_page(self) -> None:
+        self.purchased_page.reload()
+        self.stack.setCurrentWidget(self.purchased_page)
 
     def show_shopping_forecast(self) -> None:
         recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
@@ -1821,10 +1895,22 @@ class MainWindow(QtWidgets.QMainWindow):
         self._show_info_message("Bitte Admin-Karte auflegen…", auto_return_ms=None)
         uid = rfid.read_uid(show_dialog=False)
         user = models.get_user_by_uid(uid) if uid else None
+        self._admin_role = "admin"
         if not (user and user.is_admin):
             pin_dialog = PinDialog(self)
-            if pin_dialog.exec_() != QtWidgets.QDialog.Accepted or \
-                    pin_dialog.pin != models.get_admin_pin():
+            if pin_dialog.exec_() != QtWidgets.QDialog.Accepted:
+                led.indicate_error()
+                self._show_big_message("Fehler", "Kein Zugang.")
+                self.show_start_page()
+                return
+            entered_pin = pin_dialog.pin
+            admin_pin = models.get_admin_pin()
+            buyer_pin = models.get_buyer_pin()
+            if entered_pin == admin_pin:
+                self._admin_role = "admin"
+            elif entered_pin == buyer_pin:
+                self._admin_role = "buyer"
+            else:
                 led.indicate_error()
                 self._show_big_message("Fehler", "Kein Zugang.")
                 self.show_start_page()

--- a/src/models.py
+++ b/src/models.py
@@ -44,6 +44,16 @@ def set_admin_pin(pin: str, conn: Optional[sqlite3.Connection] = None) -> None:
     set_setting('admin_pin', pin, conn)
 
 
+def get_buyer_pin(conn: Optional[sqlite3.Connection] = None) -> str:
+    """Return the buyer PIN used for the limited admin GUI."""
+    return get_setting('buyer_pin', conn) or '4321'
+
+
+def set_buyer_pin(pin: str, conn: Optional[sqlite3.Connection] = None) -> None:
+    """Store the buyer PIN."""
+    set_setting('buyer_pin', pin, conn)
+
+
 def is_game_enabled(conn: Optional[sqlite3.Connection] = None) -> bool:
     """Return True if the Tic-Tac-Toe bonus game should be offered."""
     val = get_setting('tictactoe_enabled', conn)

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -170,6 +170,7 @@ def create_app() -> Flask:
         conn = database.get_connection()
         current_limit = models.get_overdraft_limit(conn)
         current_pin = models.get_admin_pin(conn)
+        current_buyer_pin = models.get_buyer_pin(conn)
         current_game_enabled = models.is_game_enabled(conn)
         current_free_day = models.is_free_day_enabled(conn)
         data_dir = Path(__file__).resolve().parent.parent / 'data'
@@ -182,8 +183,26 @@ def create_app() -> Flask:
             if val is not None:
                 models.set_overdraft_limit(int(val * 100), conn)
             pin_val = request.form.get('admin_pin')
+            buyer_pin_val = request.form.get('buyer_pin')
             if pin_val is not None:
                 models.set_admin_pin(pin_val, conn)
+                current_pin = pin_val
+            if buyer_pin_val is not None:
+                if buyer_pin_val == current_pin:
+                    conn.close()
+                    return render_template(
+                        'settings.html', overdraft_limit=current_limit,
+                        admin_pin=current_pin, buyer_pin=buyer_pin_val,
+                        game_enabled=current_game_enabled,
+                        free_day_enabled=current_free_day,
+                        qr_code_exists=qr_path.exists(),
+                        background_exists=bg_path.exists(),
+                        thank_background_exists=thank_path.exists(),
+                        free_background_exists=free_path.exists(),
+                        error='Admin-PIN und Einkäufer-PIN dürfen nicht gleich sein.'
+                    )
+                models.set_buyer_pin(buyer_pin_val, conn)
+                current_buyer_pin = buyer_pin_val
             game_val = request.form.get('game_enabled')
             new_game_state = bool(game_val)
             models.set_game_enabled(new_game_state, conn)
@@ -214,12 +233,14 @@ def create_app() -> Flask:
         conn.close()
         return render_template('settings.html', overdraft_limit=current_limit,
                                admin_pin=current_pin,
+                               buyer_pin=current_buyer_pin,
                                game_enabled=current_game_enabled,
                                free_day_enabled=current_free_day,
                                qr_code_exists=qr_path.exists(),
                                background_exists=bg_path.exists(),
                                thank_background_exists=thank_path.exists(),
-                               free_background_exists=free_path.exists())
+                               free_background_exists=free_path.exists(),
+                               error=None)
 
     @app.route('/telegram', methods=['GET', 'POST'])
     @login_required

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -2,6 +2,9 @@
 {% block content %}
 <div class="card">
     <h1>Einstellungen</h1>
+    {% if error %}
+    <p style="color:#b91c1c;font-weight:700;">{{ error }}</p>
+    {% endif %}
     <form method="post" enctype="multipart/form-data" class="form-section">
         <div class="form-grid">
             <div>
@@ -11,6 +14,10 @@
             <div>
                 <label for="admin_pin">Admin-PIN</label>
                 <input type="text" id="admin_pin" name="admin_pin" value="{{ admin_pin }}">
+            </div>
+            <div>
+                <label for="buyer_pin">Einkäufer-PIN</label>
+                <input type="text" id="buyer_pin" name="buyer_pin" value="{{ buyer_pin }}">
             </div>
         </div>
         <label class="toggle">


### PR DESCRIPTION
### Motivation
- Eine separate Kartenberechtigung "Einkäufer" mit eigenem PIN soll auf dem Touchscreen nur die Funktionen `Einkaufen`, `Eingekauft` und `Zurück` erhalten.
- Einkäufe sollen direkt über den Touchscreen als Bestandsauffüllung gebucht und wie im Webinterface dokumentiert werden.
- Admin- und Einkäufer-PINs dürfen nicht identisch sein, daher muss das Einstellungs-UI entsprechende Validierung und Persistenz haben.

### Description
- Neue Model-Helfer `get_buyer_pin` und `set_buyer_pin` hinzugefügt (`src/models.py`) und DB-Defaults/Init für `buyer_pin` ergänzt (`src/database.py`).
- Web-Einstellungen erweitert: `src/web/admin_server.py` liest/speichert `buyer_pin` und verhindert gleiche Werte von Admin- und Einkäufer-PIN; `src/web/templates/settings.html` zeigt das Feld `Einkäufer-PIN` und Fehlermeldungen an.
- Touchscreen-UI angepasst (`src/gui/main_window.py`): neuer Button `Eingekauft`, neue Seite `PurchasedPage` mit Tabelle im gleichen Sortier-/Empfehlungs-Layout wie die Einkaufsliste, `QSpinBox`-Eingaben für gekaufte Mengen und ein `Buchen`-Button, der `models.update_drink_stock` und `models.log_restock` aufruft.
- Rollen-Handling auf dem Touchscreen: Admin-Login per Karte bleibt Vollzugriff, PIN-Eingabe akzeptiert jetzt sowohl `admin_pin` (Vollzugriff) als auch `buyer_pin` (eingeschränkter Menüzugriff), und `AdminMenu.set_role` blendet Buttons entsprechend aus/ein.

### Testing
- `pytest -q` in der CI-Umgebung schlug fehl wegen fehlendem `PYTHONPATH` (ImportError beim Finden des `src`-Pakets).
- Mit `PYTHONPATH=. pytest -q` wurden die Tests ausgeführt und alle 3 Tests bestanden (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d5dc2f9c8327973286be218de1a0)