### PR TITLE
Fix visibility of navigation arrows and Admin button on start page

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1397,11 +1397,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.next_button.clicked.connect(self.next_page)
 
 
-        spacer_row = rows
-        bottom = rows + 1
-        layout.setRowStretch(spacer_row, 1)
-        layout.addWidget(self.prev_button, bottom, 0, alignment=QtCore.Qt.AlignBottom)
-        layout.addWidget(self.next_button, bottom, 1, alignment=QtCore.Qt.AlignBottom)
+        bottom = rows
+        layout.addWidget(self.prev_button, bottom, 0, alignment=QtCore.Qt.AlignLeft)
+        layout.addWidget(self.next_button, bottom, 1, alignment=QtCore.Qt.AlignHCenter)
 
         self.admin_button = QtWidgets.QPushButton("Admin")
         f = self.admin_button.font()
@@ -1413,8 +1411,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.admin_button.setProperty("accent", "admin")
         self._apply_button_style(self.admin_button)
         self.admin_button.clicked.connect(self._open_admin)
-        layout.addWidget(self.admin_button, bottom, 2,
-                         alignment=QtCore.Qt.AlignBottom | QtCore.Qt.AlignRight)
+        layout.addWidget(
+            self.admin_button,
+            bottom,
+            2,
+            alignment=QtCore.Qt.AlignRight,
+        )
         layout.setRowStretch(bottom, 0)
 
         self.prev_button.setEnabled(self.current_page > 1)


### PR DESCRIPTION
### Motivation
- The bottom navigation controls (previous/next arrows and the `Admin` button) could be pushed out of the visible area by an extra spacer row on the start page, so the layout must guarantee they render directly after the tile rows.

### Description
- In `src/gui/main_window.py` the nav row is now placed with `bottom = rows` (removed the `spacer_row`/extra `setRowStretch`) and the three controls are added with explicit alignments via `layout.addWidget(...)` (`QtCore.Qt.AlignLeft`, `QtCore.Qt.AlignHCenter`, `QtCore.Qt.AlignRight`) so the prev/next/admin buttons remain visible.

### Testing
- Compiled the changed module with `python -m py_compile src/gui/main_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03166af4d0832784662c8e05399286)