### PR TITLE
Improve touchscreen restock UI and add buyer checkbox in web user edit

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -22,6 +22,7 @@ _SCHEMA = {
         'active INTEGER NOT NULL DEFAULT 1, '
         'show_on_payment INTEGER NOT NULL DEFAULT 0, '
         'is_admin INTEGER NOT NULL DEFAULT 0, '
+        'is_buyer INTEGER NOT NULL DEFAULT 0, '
         'valid_from DATE, '
         'valid_until DATE, '
         'created_at DATETIME DEFAULT CURRENT_TIMESTAMP'
@@ -153,6 +154,10 @@ def upgrade_schema(conn: sqlite3.Connection) -> None:
     if "is_admin" not in cols:
         conn.execute(
             "ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0"
+        )
+    if "is_buyer" not in cols:
+        conn.execute(
+            "ALTER TABLE users ADD COLUMN is_buyer INTEGER NOT NULL DEFAULT 0"
         )
     if "valid_from" not in cols:
         conn.execute("ALTER TABLE users ADD COLUMN valid_from DATE")

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -808,6 +808,67 @@ class StockPage(QtWidgets.QWidget):
             self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(str(drink.min_stock)))
 
 
+class NumberInputDialog(QtWidgets.QDialog):
+    """Touch-friendly dialog to enter numeric values."""
+
+    def __init__(self, value: int = 0, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("Menge eingeben")
+        self.setWindowState(QtCore.Qt.WindowFullScreen)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.edit = QtWidgets.QLineEdit(str(value), alignment=QtCore.Qt.AlignCenter)
+        font = self.edit.font()
+        font.setPointSize(28)
+        self.edit.setFont(font)
+        self.edit.setReadOnly(True)
+        layout.addWidget(self.edit)
+
+        grid = QtWidgets.QGridLayout()
+        buttons = [
+            ('1', 0, 0), ('2', 0, 1), ('3', 0, 2),
+            ('4', 1, 0), ('5', 1, 1), ('6', 1, 2),
+            ('7', 2, 0), ('8', 2, 1), ('9', 2, 2),
+            ('←', 3, 0), ('0', 3, 1), ('C', 3, 2),
+        ]
+        for text, r, c in buttons:
+            btn = QtWidgets.QPushButton(text)
+            bf = btn.font(); bf.setPointSize(24); btn.setFont(bf)
+            btn.setMinimumSize(120, 90)
+            grid.addWidget(btn, r, c)
+            if text.isdigit():
+                btn.clicked.connect(lambda _, t=text: self._append_digit(t))
+            elif text == '←':
+                btn.clicked.connect(lambda _=None: self.edit.backspace())
+            else:
+                btn.clicked.connect(self._clear)
+        layout.addLayout(grid)
+
+        btn_row = QtWidgets.QHBoxLayout()
+        ok_btn = QtWidgets.QPushButton("Bestätigen")
+        cancel_btn = QtWidgets.QPushButton("Abbrechen")
+        for btn in (ok_btn, cancel_btn):
+            bf = btn.font(); bf.setPointSize(20); btn.setFont(bf)
+            btn.setMinimumHeight(70)
+            btn_row.addWidget(btn)
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        layout.addLayout(btn_row)
+
+    def _append_digit(self, digit: str) -> None:
+        if self.edit.text() == '0':
+            self.edit.setText(digit)
+        else:
+            self.edit.setText(f"{self.edit.text()}{digit}")
+
+    def _clear(self) -> None:
+        self.edit.setText('0')
+
+    @property
+    def value(self) -> int:
+        return int(self.edit.text() or '0')
+
+
 class PurchasedPage(QtWidgets.QWidget):
     """Page to book purchased bottles (restock) from touchscreen."""
 
@@ -819,10 +880,22 @@ class PurchasedPage(QtWidgets.QWidget):
         self.table.setHorizontalHeaderLabels(["Getränk", "Bestand", "Gekauft"])
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
-        header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.Fixed)
+        header.setSectionResizeMode(2, QtWidgets.QHeaderView.Fixed)
+        self.table.setColumnWidth(1, 220)
+        self.table.setColumnWidth(2, 260)
         self.table.verticalHeader().setVisible(False)
+        self.table.verticalHeader().setDefaultSectionSize(72)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
         layout.addWidget(self.table)
+
+        scroll_row = QtWidgets.QHBoxLayout()
+        self.scroll_up_btn = QtWidgets.QPushButton("▲ Nach oben")
+        self.scroll_down_btn = QtWidgets.QPushButton("▼ Nach unten")
+        scroll_row.addWidget(self.scroll_up_btn)
+        scroll_row.addWidget(self.scroll_down_btn)
+        layout.addLayout(scroll_row)
+
         button_row = QtWidgets.QHBoxLayout()
         self.book_btn = QtWidgets.QPushButton("Buchen")
         self.back_btn = QtWidgets.QPushButton("Zurück")
@@ -830,6 +903,8 @@ class PurchasedPage(QtWidgets.QWidget):
         button_row.addWidget(self.back_btn)
         layout.addLayout(button_row)
         self.book_btn.clicked.connect(self.book)
+        self.scroll_up_btn.clicked.connect(lambda: self._scroll_rows(-3))
+        self.scroll_down_btn.clicked.connect(lambda: self._scroll_rows(3))
 
     def reload(self) -> None:
         recs = models.get_purchase_recommendations(days=30, coverage_days=21, replenish_cycle_days=45)
@@ -843,7 +918,22 @@ class PurchasedPage(QtWidgets.QWidget):
             spin = QtWidgets.QSpinBox()
             spin.setRange(0, 10000)
             spin.setValue(0)
+            spin.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+            spin.setMinimumHeight(58)
+            font = spin.font(); font.setPointSize(20); spin.setFont(font)
+            spin.lineEdit().setAlignment(QtCore.Qt.AlignCenter)
+            spin.lineEdit().setReadOnly(True)
+            spin.mousePressEvent = lambda event, s=spin: self._open_touch_keyboard(s)
             self.table.setCellWidget(row, 2, spin)
+
+    def _scroll_rows(self, delta: int) -> None:
+        bar = self.table.verticalScrollBar()
+        bar.setValue(bar.value() + delta)
+
+    def _open_touch_keyboard(self, spin: QtWidgets.QSpinBox) -> None:
+        dlg = NumberInputDialog(spin.value(), self)
+        if dlg.exec_() == QtWidgets.QDialog.Accepted:
+            spin.setValue(min(max(dlg.value, spin.minimum()), spin.maximum()))
 
     def book(self) -> None:
         booked = 0

--- a/src/web/admin_server.py
+++ b/src/web/admin_server.py
@@ -683,6 +683,7 @@ def create_app() -> Flask:
             balance_euro = request.form.get('balance', type=float)
             is_event = 1 if request.form.get('is_event') else 0
             is_admin = 1 if request.form.get('is_admin') else 0
+            is_buyer = 1 if request.form.get('is_buyer') else 0
             active = 1 if request.form.get('active') else 0
             show_on_payment = 1 if request.form.get('show_on_payment') and is_event else 0
             valid_from = (request.form.get('valid_from') or '').strip() or None
@@ -691,7 +692,7 @@ def create_app() -> Flask:
                 valid_from = None
                 valid_until = None
             conn.execute(
-                'UPDATE users SET name=?, rfid_uid=?, balance=?, is_event=?, active=?, show_on_payment=?, is_admin=?, valid_from=?, valid_until=? WHERE id=?',
+                'UPDATE users SET name=?, rfid_uid=?, balance=?, is_event=?, active=?, show_on_payment=?, is_admin=?, is_buyer=?, valid_from=?, valid_until=? WHERE id=?',
                 (
                     name,
                     uid,
@@ -700,6 +701,7 @@ def create_app() -> Flask:
                     active,
                     show_on_payment,
                     is_admin,
+                    is_buyer,
                     valid_from,
                     valid_until,
                     user_id,

--- a/src/web/templates/user_edit.html
+++ b/src/web/templates/user_edit.html
@@ -13,6 +13,7 @@
         <label><input type="checkbox" name="show_on_payment" value="1" {% if user['show_on_payment'] %}checked{% endif %}> Auf Zahlungsmethoden anzeigen</label><br>
         {% endif %}
         <label><input type="checkbox" name="is_admin" value="1" {% if user['is_admin'] %}checked{% endif %}> Adminzugang</label><br>
+        <label><input type="checkbox" name="is_buyer" value="1" {% if user['is_buyer'] %}checked{% endif %}> Einkäuferzugang</label><br>
       <label><input type="checkbox" name="active" value="1" {% if user['active'] %}checked{% endif %}> Aktiv</label><br>
       <button type="submit">Speichern</button>
   </form>


### PR DESCRIPTION
### Motivation
- Improve touchscreen usability of the "Eingekauft" (restock) page by making quantity entry and navigation usable without fine-grained scrolling or small controls. 
- Provide an on-screen numeric keypad for entering amounts similar to the existing PIN dialog so values can be entered comfortably on a tablet. 
- Expose and persist a missing "Einkäufer" (buyer) flag in the web user edit UI and backend so buyer-role users can be managed from the web interface.

### Description
- Added a full-screen `NumberInputDialog` in `src/gui/main_window.py` which provides a touch-optimized numeric keypad and returns an integer value. 
- Modified `PurchasedPage` in `src/gui/main_window.py` to use fixed/wider column widths, increase default row height, hide spinbox buttons, set larger fonts, add `▲ Nach oben`/`▼ Nach unten` scroll buttons, and wire quantity cell taps to open the on-screen numeric keypad via `_open_touch_keyboard` and `_scroll_rows` handlers. 
- Extended database schema and migrations in `src/database.py` to include `users.is_buyer` in the `users` table and to add the column automatically in `upgrade_schema` if missing. 
- Updated the web handler `user_edit` in `src/web/admin_server.py` to read `is_buyer` from the form and persist it in the `UPDATE users ... is_buyer ...` statement. 
- Added the `Einkäuferzugang` checkbox to the web template `src/web/templates/user_edit.html` so the flag can be toggled in the UI.

### Testing
- Ran `python -m py_compile src/gui/main_window.py src/web/admin_server.py src/database.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031d1590008327876f5f839bea4d3a)