### PR TITLE
Add missing is_buyer field to User dataclass

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -109,6 +109,7 @@ class User:
     active: int = 1
     show_on_payment: int = 0
     is_admin: int = 0
+    is_buyer: int = 0
     valid_from: Optional[str] = None
     valid_until: Optional[str] = None
     created_at: Optional[str] = None


### PR DESCRIPTION
### Motivation
- Loading users from the database can raise `TypeError: User.__init__() got an unexpected keyword argument 'is_buyer'` because the `users` table includes an `is_buyer` column but the `User` dataclass did not declare it.

### Description
- Add `is_buyer: int = 0` to the `User` dataclass in `src/models.py` so `User(**row)` matches the `users` table schema.

### Testing
- Ran `python -m py_compile src/models.py` which succeeded, verifying the module compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031fc795788327bfbd141b9fdec880)