### PR TITLE
Fix touchscreen UI bottom-button visibility and buyer admin access

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -814,8 +814,10 @@ class NumberInputDialog(QtWidgets.QDialog):
     def __init__(self, value: int = 0, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setWindowTitle("Menge eingeben")
-        self.setWindowState(QtCore.Qt.WindowFullScreen)
+        self.setWindowState(QtCore.Qt.WindowMaximized)
         layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
 
         self.edit = QtWidgets.QLineEdit(str(value), alignment=QtCore.Qt.AlignCenter)
         font = self.edit.font()
@@ -834,7 +836,7 @@ class NumberInputDialog(QtWidgets.QDialog):
         for text, r, c in buttons:
             btn = QtWidgets.QPushButton(text)
             bf = btn.font(); bf.setPointSize(24); btn.setFont(bf)
-            btn.setMinimumSize(120, 90)
+            btn.setMinimumSize(110, 72)
             grid.addWidget(btn, r, c)
             if text.isdigit():
                 btn.clicked.connect(lambda _, t=text: self._append_digit(t))
@@ -849,7 +851,7 @@ class NumberInputDialog(QtWidgets.QDialog):
         cancel_btn = QtWidgets.QPushButton("Abbrechen")
         for btn in (ok_btn, cancel_btn):
             bf = btn.font(); bf.setPointSize(20); btn.setFont(bf)
-            btn.setMinimumHeight(70)
+            btn.setMinimumHeight(58)
             btn_row.addWidget(btn)
         ok_btn.clicked.connect(self.accept)
         cancel_btn.clicked.connect(self.reject)
@@ -976,6 +978,8 @@ class AdminMenu(QtWidgets.QWidget):
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
 
         self.stock_btn = QtWidgets.QPushButton("Einkaufen")
         self.purchased_btn = QtWidgets.QPushButton("Eingekauft")
@@ -999,12 +1003,10 @@ class AdminMenu(QtWidgets.QWidget):
             f = btn.font()
             f.setPointSize(20)
             btn.setFont(f)
-            btn.setMinimumHeight(60)
+            btn.setMinimumHeight(56)
             layout.addWidget(btn)
 
         self.reload_web_qr()
-
-        layout.addStretch(1)
 
     def set_role(self, role: str) -> None:
         is_buyer = role == "buyer"
@@ -2006,7 +2008,11 @@ class MainWindow(QtWidgets.QMainWindow):
         uid = rfid.read_uid(show_dialog=False)
         user = models.get_user_by_uid(uid) if uid else None
         self._admin_role = "admin"
-        if not (user and user.is_admin):
+        if user and user.is_admin:
+            self._admin_role = "admin"
+        elif user and user.is_buyer:
+            self._admin_role = "buyer"
+        else:
             pin_dialog = PinDialog(self)
             if pin_dialog.exec_() != QtWidgets.QDialog.Accepted:
                 led.indicate_error()


### PR DESCRIPTION
### Motivation
- Lower buttons (e.g. “Zurück” and confirm/cancel in the numeric keypad) were not reliably visible on small/touch displays.  
- A user with purchase rights (`is_buyer`) could not enter the limited buyer admin menu via the touchscreen `Admin` flow without entering the buyer PIN.

### Description
- Reduced margins/spacing and button minimum heights in the admin menu to make bottom buttons fit on low-height screens, removed the trailing `layout.addStretch(1)` to avoid pushing controls off-screen, and added `layout.setContentsMargins` / `setSpacing` for consistent spacing (file `src/gui/main_window.py`).
- Changed the numeric keypad dialog from fullscreen to maximized with tighter internal margins/spacing and slightly smaller button sizes so the confirm/cancel row remains visible (file `src/gui/main_window.py`).
- Updated the admin entry flow to grant the `buyer` role immediately when an `is_buyer` card is presented (so buyers can open the buyer admin menu directly via the `Admin` button), while preserving the PIN fallback behavior for other users (file `src/gui/main_window.py`).

### Testing
- Ran `pytest -q tests/test_booking_logic.py` without `PYTHONPATH` which failed during collection due to module import path, as expected.  
- Ran `PYTHONPATH=. pytest -q tests/test_booking_logic.py` which completed successfully with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0323c35f008327b4303e26e7f2814e)