### PR TITLE
Zahlenfeld-Button in "Gekauft"-Tabelle verkleinern

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -943,12 +943,13 @@ class PurchasedPage(QtWidgets.QWidget):
             spin.lineEdit().setAlignment(QtCore.Qt.AlignCenter)
             spin.mousePressEvent = lambda event, s=spin: self._open_touch_keyboard(s)
             open_pad_btn = QtWidgets.QPushButton("Zahlenfeld")
-            open_pad_btn.setMinimumHeight(58)
+            open_pad_btn.setMinimumHeight(46)
+            open_pad_btn.setMinimumWidth(118)
             btn_font = open_pad_btn.font()
-            btn_font.setPointSize(16)
+            btn_font.setPointSize(13)
             open_pad_btn.setFont(btn_font)
             open_pad_btn.setStyleSheet(
-                "QPushButton { background: #2563eb; color: white; border-radius: 10px; font-weight: 700; padding: 4px 10px; }"
+                "QPushButton { background: #2563eb; color: white; border-radius: 8px; font-weight: 700; padding: 2px 8px; }"
                 "QPushButton:pressed { background: #1d4ed8; }"
             )
             open_pad_btn.clicked.connect(lambda _, s=spin: self._open_touch_keyboard(s))


### PR DESCRIPTION
### Motivation
- Auf kleineren Displays passten die Buttons im Zahlungs-/Zahlenfeld nicht vollständig auf die Anzeige, daher sollten die `Zahlenfeld`-Buttons kompakter werden, damit alle Bedienelemente sichtbar bleiben.
- Die Änderung betrifft nur die Anzeigegröße in der Seite zum Buchen (PurchasedPage) und soll kein Laufzeitverhalten ändern.

### Description
- Anpassung in `src/gui/main_window.py` auf der `PurchasedPage`-Reload-Logik für den `Zahlenfeld`-Button (`open_pad_btn`).
- Verringertes Minimum-Height von `58` auf `46` und hinzugefügte `setMinimumWidth(118)` für konsistenten Textumbruch.
- Schriftgröße des Buttons von Punktgröße `16` auf `13` reduziert.
- Button-CSS angepasst: kleinere `border-radius` (`10` → `8`) und reduziertes `padding` (`4px 10px` → `2px 8px`).

### Testing
- `python -m py_compile src/gui/main_window.py` wurde ausgeführt und beendete sich erfolgreich.  
- Es wurden keine funktionalen Tests benötigt, da nur UI-Größen/Styling verändert wurden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03298e31708327837032769eed5812)