### PR TITLE
Fix touch keypad dialog button layout and wiring

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -837,7 +837,26 @@ class NumberInputDialog(QtWidgets.QDialog):
         ]
         for text, r, c in buttons:
             btn = QtWidgets.QPushButton(text)
-            bf = btn.font(); bf.setPointSize(17); btn.setFont(bf)
+            bf = btn.font()
+            bf.setPointSize(17)
+            btn.setFont(bf)
+            btn.setMinimumHeight(58)
+            grid.addWidget(btn, r, c)
+            if text.isdigit():
+                btn.clicked.connect(lambda _, t=text: self._append_digit(t))
+            elif text == '←':
+                btn.clicked.connect(lambda _=None: self.edit.backspace())
+            else:  # 'C'
+                btn.clicked.connect(self._clear)
+        layout.addLayout(grid)
+
+        btn_row = QtWidgets.QHBoxLayout()
+        ok_btn = QtWidgets.QPushButton("OK")
+        cancel_btn = QtWidgets.QPushButton("Abbrechen")
+        for btn in (ok_btn, cancel_btn):
+            bf = btn.font()
+            bf.setPointSize(17)
+            btn.setFont(bf)
             btn.setMinimumHeight(58)
             btn_row.addWidget(btn)
         ok_btn.clicked.connect(self.accept)


### PR DESCRIPTION
### Motivation

- The touch-friendly `NumberInputDialog` crashed with `NameError: name 'btn_row' is not defined` because keypad buttons were added to `btn_row` before it existed.
- The numeric keypad previously did not update the dialog input because button signals were not connected to the dialog methods.
- The dialog needs a clear bottom action row with `OK` / `Abbrechen` to preserve accept/reject behavior on confirmation.

### Description

- Replace the erroneous `btn_row.addWidget(btn)` inside the keypad loop with `grid.addWidget(btn, r, c)` to place keys in a `QGridLayout`.
- Wire digit buttons to `self._append_digit`, wire the backspace key to `self.edit.backspace()`, and wire the clear key to `self._clear` so the read-only `QLineEdit` is updated by the keypad.
- Add an explicit `btn_row = QtWidgets.QHBoxLayout()` with `OK` and `Abbrechen` buttons, set fonts and minimum heights, and connect them to `accept`/`reject` to restore confirmation/cancel flows.
- Tidy up font assignment and layout sequencing so the keypad grid is added before the action row.

### Testing

- Ran `python -m py_compile src/gui/main_window.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032e7f8b4c832788464fcf24f1bd3f)